### PR TITLE
Add a flag to create a JSON log file, add the full flag list to the JSON output

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,6 +36,8 @@ def main(mainargs=None):
         help="Write an unfilled plan file")
     parser.add_argument('--timeout', type=float, required=False,
         help="Timeout generating the seed after the specified number of seconds")
+    parser.add_argument('--logdirectory', dest="log_directory", type=str, required=False,
+        help="Directory to write the JSON log file. Generated independently from the spoiler log and omitted by default.")
 
     # Flags that effect gameplay
     parser.add_argument('--plan', dest="plan", metavar='plandomizer', type=str, required=False,

--- a/randomizer.py
+++ b/randomizer.py
@@ -2,6 +2,7 @@ import random
 import zipfile
 import os
 import binascii
+from datetime import datetime
 
 import explorer
 import logic
@@ -69,11 +70,16 @@ class Randomizer:
                     handle.close()
                 else:
                     rom.save(fname, name="LADXR")
-                if options.spoilerformat != "none" and not options.race:
-                    extension = "json" if options.spoilerformat == "json" else "txt"
-                    sfname = "LADXR_Multiworld_%d_%d.%s" % (options.multiworld, n + 1, extension)
+                if (options.spoilerformat != "none" or options.log_directory) and not options.race:
                     log = spoilerLog.SpoilerLog(options, rom)
-                    log.output(sfname, z)
+                    if options.log_directory:
+                        filename = "LADXR_Multiworld_%d_%d_%s_%s.json" % (options.multiworld, n + 1, datetime.now().strftime("%Y-%m-%d_%H-%M-%S"), log.seed)
+                        log_path = os.path.join(options.log_directory, filename)
+                        log.outputJson(log_path)
+                    if options.spoilerformat != "none":
+                        extension = "json" if options.spoilerformat == "json" else "txt"
+                        sfname = "LADXR_Multiworld_%d_%d.%s" % (options.multiworld, n + 1, extension)
+                        log.output(sfname, z)
         else:
             rom = generator.generateRom(options, self.seed, self.__logic)
             filename = options.output_filename
@@ -81,9 +87,14 @@ class Randomizer:
                 filename = "LADXR_%s.gbc" % (binascii.hexlify(self.seed).decode("ascii").upper())
             rom.save(filename, name="LADXR")
 
-            if options.spoilerformat != "none" and not options.race:
+            if (options.spoilerformat != "none" or options.log_directory) and not options.race:
                 log = spoilerLog.SpoilerLog(options, rom)
-                log.output(options.spoiler_filename)
+                if options.log_directory:
+                    filename = "LADXR_%s_%s.json" % (datetime.now().strftime("%Y-%m-%d_%H-%M-%S"), log.seed)
+                    log_path = os.path.join(options.log_directory, filename)
+                    log.outputJson(log_path)
+                if options.spoilerformat != "none":
+                    log.output(options.spoiler_filename)
 
     def readItemPool(self, options, item_placer):
         item_pool = {}

--- a/spoilerLog.py
+++ b/spoilerLog.py
@@ -49,6 +49,7 @@ class SpoilerLog:
         self.accessibleItems = []
         self.inaccessibleItems = None
         self.outputFormat = args.spoilerformat
+        self.args = vars(args)
 
         # Assume the broadest settings if we're dumping a seed we didn't just create
         if args.dump:


### PR DESCRIPTION
This is what I came up with to make things easier for the data gathering thing I have planned and the logging you mentioned. The idea is that if you set the logdirectory flag, it will create a JSON spoiler log in that directory in addition to whatever normal spoiler log behavior is specified. All JSON output now also includes a list of the whole arg list.