### PR TITLE
Linux support for multiworld connector

### DIFF
--- a/multiworld/bizhawkConnector.lua
+++ b/multiworld/bizhawkConnector.lua
@@ -53,12 +53,29 @@ if memory ~= nil and gui ~= nil then
 else
     --Assume we are the arduino connector
 
-    local seriallib = require "serial"
-    local serial = io.open("\\\\.\\COM27", "w+")
-    serial:setvbuf("no")
-    seriallib.flush(serial)
-    seriallib.setSerial(serial, 115200, 8, 1, 0)
-    seriallib.setTimeout(serial, 100, 0)
+    local serial = nil
+
+    -- Setup serial connection
+    -- We do this differently under windows and unix-based systems because of a limiation in the lua-serial library:
+    -- https://github.com/javalikescript/luaserial/blob/master/luaserial_linux.c#L224
+    -- No support for setTimeout in Linux, which is necessary for the rest of the logic to function properly.
+    local BinaryFormat = package.cpath:match("%p[\\|/]?%p(%a+)")
+    if BinaryFormat == "dll" then -- dlls, we are in windows
+        local seriallib = require "serial"
+        serial = io.open("\\\\.\\COM27", "w+")
+        serial:setvbuf("no")
+        seriallib.flush(serial)
+        seriallib.setSerial(serial, 115200, 8, 1, 0)
+        seriallib.setTimeout(serial, 100, 0)
+    else -- linux, mac os
+        -- Time is in tenth of seconds
+        -- Use dmesg to ensure the arduino is actually /dev/ttyUSB0.
+        -- Accessing ttyUSB0 requires setting up permissions under linux (i.e. adding your user to the dialout group).
+        os.execute("stty -F /dev/ttyUSB0 115200 raw min 0 time 1 -echo -echoe -echok -echoctl -echoke")
+        serial = io.open("/dev/ttyUSB0", "w+")
+        os.execute("sleep 5")
+    end
+
 
     print("Connecting to Arduino...")
     while true do


### PR DESCRIPTION
Lua-serial does not support setTimeout in Linux: https://github.com/javalikescript/luaserial/blob/master/luaserial_linux.c#L224

As a result, the connector does not function properly.

This PR splits the serial setup phase in 2 branches depending on the OS: using lua-serial for windows, and stty for unix-based systems.