### PR TITLE
multiworld connector: fix repeated error message on bad server connection

### DIFF
--- a/multiworld/bizhawkConnector.lua
+++ b/multiworld/bizhawkConnector.lua
@@ -283,7 +283,7 @@ function stateError()
         socket = nil
     end
 
-    drawText("Disconnected")
+    drawtext("Disconnected")
 end
 
 function sendAll(data)


### PR DESCRIPTION
Due to a casing typo, the multiworld connector would flood the console box with an error message when the server connection failed. This fixes that.