### PR TITLE
small logic fixes, add boots superhop for hell logic

### DIFF
--- a/logic/dungeon1.py
+++ b/logic/dungeon1.py
@@ -7,7 +7,7 @@ class Dungeon1:
     def __init__(self, options, world_setup, r):
         entrance = Location(1)
         entrance.add(DungeonChest(0x113), DungeonChest(0x115), DungeonChest(0x10E))
-        Location(1).add(DroppedKey(0x116)).connect(entrance, r.push_hardhat) # hardhat beetles (can kill with bomb)
+        Location(1).add(DroppedKey(0x116)).connect(entrance, OR(BOMB, r.push_hardhat)) # hardhat beetles (can kill with bomb)
         Location(1).add(DungeonChest(0x10D)).connect(entrance, OR(r.attack_hookshot_powder, SHIELD)) # moldorm spawn chest
         stalfos_keese_room = Location(1).add(DungeonChest(0x114)).connect(entrance, r.attack_hookshot) # 2 stalfos 2 keese room
         Location(1).add(DungeonChest(0x10C)).connect(entrance, BOMB) # hidden seashell room

--- a/logic/dungeon2.py
+++ b/logic/dungeon2.py
@@ -14,7 +14,7 @@ class Dungeon2:
         Location(2).add(DungeonChest(0x137)).connect(dungeon2_r2, AND(KEY2, FOUND(KEY2, 5), OR(r.rear_attack, r.rear_attack_range)))  # compass chest
         if options.owlstatues == "both" or options.owlstatues == "dungeon":
             Location(2).add(OwlStatue(0x133)).connect(dungeon2_r2, STONE_BEAK2)
-        dungeon2_r3 = Location(2).add(DungeonChest(0x138)).connect(dungeon2_r2, r.attack)  # first chest with key
+        dungeon2_r3 = Location(2).add(DungeonChest(0x138)).connect(dungeon2_r2, r.attack_hookshot)  # first chest with key, can hookshot the switch in previous room
         dungeon2_r4 = Location(2).add(DungeonChest(0x139)).connect(dungeon2_r3, FEATHER)  # button spawn chest
         if options.logic == "casual":
             shyguy_key_drop = Location(2).add(DroppedKey(0x134)).connect(dungeon2_r3, AND(FEATHER, OR(r.rear_attack, r.rear_attack_range)))  # shyguy drop key

--- a/logic/dungeon3.py
+++ b/logic/dungeon3.py
@@ -66,15 +66,16 @@ class Dungeon3:
             dungeon3_south_key_drop.connect(area_down, POWER_BRACELET) # use pots to kill enemies
 
         if options.logic == 'glitched' or options.logic == 'hell':
-            area3.connect(dungeon3_raised_blocks_east, FEATHER, one_way=True) # use superjump to get over the bottom left block
+            area2.connect(dungeon3_raised_blocks_east, AND(r.attack_hookshot_powder, FEATHER), one_way=True) # use superjump to get over the bottom left block
             area3.connect(dungeon3_raised_blocks_north, AND(OR(PEGASUS_BOOTS, HOOKSHOT), FEATHER), one_way=True) # use shagjump (unclipped superjump next to movable block) from north wall to get on the blocks. Instead of boots can also get to that area with a hookshot clip past the movable block
             area3.connect(dungeon3_zol_stalfos, HOOKSHOT, one_way=True) # hookshot clip through the northern push block next to raised blocks chest to get to the zol
             dungeon3_nightmare_key_chest.connect(area_right, AND(FEATHER, BOMB)) # superjump to right side 3 gap via top wall and jump the 2 gap
             dungeon3_post_dodongo_chest.connect(area_right, AND(FEATHER, FOUND(KEY3, 5))) # superjump from keyblock path. use 1 key to open first block + text clip 2nd block
         
         if options.logic == 'hell':
-            area3.connect(dungeon3_raised_blocks_north, AND(PEGASUS_BOOTS, BOW), one_way=True) # use boots superjump off top wall
-            dungeon3_zol_stalfos.connect(area_up, AND(FEATHER, SWORD)) # use superjump near top blocks chest to get to zol without boots. TODO: Nag messages removes sword req
+            area2.connect(dungeon3_raised_blocks_east, AND(PEGASUS_BOOTS, OR(BOW, MAGIC_ROD)), one_way=True) # use boots superhop to get over the bottom left block
+            area3.connect(dungeon3_raised_blocks_north, AND(PEGASUS_BOOTS, OR(BOW, MAGIC_ROD)), one_way=True) # use boots superhop off top wall or left wall to get on raised blocks
+            area_up.connect(dungeon3_zol_stalfos, AND(FEATHER, OR(BOW, MAGIC_ROD, SWORD)), one_way=True) # use superjump near top blocks chest to get to zol without boots, keep wall clip on right wall to get a clip on left wall or use obstacles
             area_left_key_drop.connect(area_left, SHIELD) # knock everything into the pit including the teleporting owls
             dungeon3_south_key_drop.connect(area_down, SHIELD) # knock everything into the pit including the teleporting owls
             dungeon3_nightmare_key_chest.connect(area_right, AND(FEATHER, SHIELD)) # superjump into jumping stalfos and shield bump to right ledge

--- a/logic/dungeon7.py
+++ b/logic/dungeon7.py
@@ -26,8 +26,9 @@ class Dungeon7:
         final_pillar_area = Location(7).add(DungeonChest(0x21C)).connect(bottomleftF2_area, AND(BOMB, HOOKSHOT))  # chest that needs to spawn to get to the last pillar
         final_pillar = Location(7).connect(final_pillar_area, POWER_BRACELET) # decouple chest from pillar
 
-        pre_boss = Location(7).connect(final_pillar, NIGHTMARE_KEY7) 
-        beamos_horseheads = Location(7).add(DungeonChest(0x220)).connect(pre_boss, POWER_BRACELET) # 100 rupee chest / medicine chest (DX) behind boss door
+        beamos_horseheads_area = Location(7).connect(final_pillar, NIGHTMARE_KEY7) # area behind boss door
+        beamos_horseheads = Location(7).add(DungeonChest(0x220)).connect(beamos_horseheads_area, POWER_BRACELET) # 100 rupee chest / medicine chest (DX) behind boss door
+        pre_boss = Location(7).connect(beamos_horseheads_area, HOOKSHOT) # raised plateau before boss staircase
         boss = Location(7).add(HeartContainer(0x223), Instrument(0x22c)).connect(pre_boss, r.boss_requirements[world_setup.boss_mapping[6]])
 
         if options.dungeon_items not in {'localnightmarekey', 'keysanity', 'keysy'}:
@@ -42,8 +43,12 @@ class Dungeon7:
                 bottomleft_owl.connect(bottomleftF2_area, STONE_BEAK7) # sideways block push to get to the owl statue (attack_hookshot is already implied from bottomleftF2_area)
             final_pillar.connect(bottomleftF2_area, BOMB) # bomb trigger pillar
             pre_boss.connect(final_pillar, FEATHER) # superjump on top of goomba to extend superjump to boss door plateau
+            pre_boss.connect(beamos_horseheads_area, None, one_way=True) # can drop down from raised plateau to beamos horseheads area
             
         if options.logic == 'hell':
             topright_pillar_area.connect(entrance, FEATHER) # superjump in the center to get on raised blocks, has to be low
+            topright_pillar_area.connect(entrance, AND(PEGASUS_BOOTS, OR(BOW, MAGIC_ROD))) # boots superhop in the center to get on raised blocks
+            toprightF1_chest.connect(topright_pillar_area, AND(PEGASUS_BOOTS, OR(BOW, MAGIC_ROD))) # boots superhop from F1 switch room
+            pre_boss.connect(final_pillar, AND(PEGASUS_BOOTS, OR(BOW, MAGIC_ROD))) # boots superhop on top of goomba to extend superhop to boss door plateau
         
         self.entrance = entrance

--- a/logic/dungeon8.py
+++ b/logic/dungeon8.py
@@ -61,7 +61,7 @@ class Dungeon8:
         middle_center_2.connect(up_left, AND(BOMB, FEATHER), one_way=True) # does this even skip a key? both middle_center_2 and up_left come from upper_center with 1 extra key
 
         bossdoor = Location(8).connect(entrance_up, AND(FEATHER, MAGIC_ROD))
-        boss = Location(8).add(HeartContainer(0x234), Instrument(0x230)).connect(entrance_up, AND(NIGHTMARE_KEY8, r.boss_requirements[world_setup.boss_mapping[7]]))
+        boss = Location(8).add(HeartContainer(0x234), Instrument(0x230)).connect(bossdoor, AND(NIGHTMARE_KEY8, r.boss_requirements[world_setup.boss_mapping[7]]))
         
         if options.logic == 'hard' or options.logic == 'glitched' or options.logic == 'hell':
             entrance_left.connect(entrance, BOMB) # use bombs to kill vire and hinox

--- a/logic/dungeonColor.py
+++ b/logic/dungeonColor.py
@@ -17,17 +17,24 @@ class DungeonColor:
         room2_lights.add(DroppedKey(0x308))
 
         Location(9).connect(room2, AND(KEY9, FOUND(KEY9, 3), r.miniboss_requirements[world_setup.miniboss_mapping["c2"]])).add(DungeonChest(0x302))  # nightmare key after slime mini boss
-        room3 = Location(9).connect(room2_weapon, AND(KEY9, FOUND(KEY9, 2), r.miniboss_requirements[world_setup.miniboss_mapping["c1"]])) # After the miniboss
+        room3 = Location(9).connect(room2, AND(KEY9, FOUND(KEY9, 2), r.miniboss_requirements[world_setup.miniboss_mapping["c1"]])) # After the miniboss
         room4 = Location(9).connect(room3, POWER_BRACELET)  # need to lift a pot to reveal button
         room4.add(DungeonChest(0x306))  # map
-        room4.add(DroppedKey(0x307))
+        room4karakoro = Location(9).add(DroppedKey(0x307)).connect(room4, r.attack_hookshot)  # require item to knock Karakoro enemies into shell
         if options.owlstatues == "both" or options.owlstatues == "dungeon":
             Location(9).add(OwlStatue(0x30A)).connect(room4, STONE_BEAK9)
-        room5 = Location(9).connect(room4, AND(KEY9, FOUND(KEY9, 3)))  # before the boss
-        boss = Location(9).connect(room5, AND(NIGHTMARE_KEY9, r.boss_requirements[world_setup.boss_mapping[8]]))
+        room5 = Location(9).connect(room4, OR(r.attack_hookshot, SHIELD)) # lights room
+        room6 = Location(9).connect(room5, AND(KEY9, FOUND(KEY9, 3))) # room with switch and nightmare door
+        pre_boss = Location(9).connect(room6, OR(r.attack_hookshot, AND(PEGASUS_BOOTS, FEATHER)))  # before the boss, require item to hit switch or jump past raised blocks
+        boss = Location(9).connect(pre_boss, AND(NIGHTMARE_KEY9, r.boss_requirements[world_setup.boss_mapping[8]]))
         boss.add(TunicFairy(0), TunicFairy(1))
 
-        if options.logic == 'hard' or options.logic == 'glitched':
+        if options.logic == 'hard' or options.logic == 'glitched' or options.logic == 'hell':
             room2.connect(entrance, POWER_BRACELET) # throw pots at enemies
+            pre_boss.connect(room6, FEATHER)  # before the boss, jump past raised blocks without boots
 
+        if options.logic == 'hell':
+            room2_weapon.connect(room2, SHIELD) # shield bump karakoro into the holes
+            room4karakoro.connect(room4, SHIELD) # shield bump karakoro into the holes
+            
         self.entrance = entrance

--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -25,6 +25,7 @@ class World:
         self._addEntrance("library", mabe_village, None, None)
         self._addEntrance("trendy_shop", mabe_village, None, r.bush)
         self._addEntrance("d1", mabe_village, None, TAIL_KEY)
+        self._addEntranceRequirementExit("d1", None) # if exiting, you do not need the key
 
         start_house = Location().add(StartItem())
         self._addEntrance("start_house", mabe_village, start_house, None)
@@ -135,7 +136,9 @@ class World:
 
         dungeon3_entrance = Location().connect(ukuku_prairie, OR(FEATHER, FLIPPERS))
         self._addEntrance("d3", dungeon3_entrance, None, SLIME_KEY)
+        self._addEntranceRequirementExit("d3", None) # if exiting, you do not need to open the door
         Location().add(Seashell(0x0A5)).connect(dungeon3_entrance, SHOVEL)  # above lv3
+        dungeon3_entrance.connect(ukuku_prairie, None, one_way=True) # jump down ledge back to ukuku_prairie
 
         prairie_island_seashell = Location().add(Seashell(0x0A6)).connect(ukuku_prairie, AND(FLIPPERS, r.bush))  # next to lv3
         Location().add(Seashell(0x08B)).connect(ukuku_prairie, r.bush)  # next to seashell house
@@ -209,7 +212,7 @@ class World:
         self._addEntrance("castle_upper_left", castle_top_outside, castle_inside, None)
         self._addEntrance("castle_upper_right", castle_top_outside, castle_top_inside, None)
         Location().add(GoldLeaf(0x05A)).connect(castle_outside, OR(SWORD, BOW, MAGIC_ROD))  # mad bomber, enemy hiding in the 6 holes
-        crow_gold_leaf = Location().add(GoldLeaf(0x058)).connect(castle_outside, AND(POWER_BRACELET, r.attack_no_bomb))  # bird on tree, can't kill with bomb cause it flies off. immune to magic_powder
+        crow_gold_leaf = Location().add(GoldLeaf(0x058)).connect(castle_outside, AND(POWER_BRACELET, r.attack_hookshot_no_bomb))  # bird on tree, can't kill with bomb cause it flies off. immune to magic_powder
         Location().add(GoldLeaf(0x2D2)).connect(castle_inside, r.attack_hookshot_powder)  # in the castle, kill enemies
         Location().add(GoldLeaf(0x2C5)).connect(castle_inside, AND(BOMB, r.attack_hookshot_powder))  # in the castle, bomb wall to show enemy
         kanalet_chain_trooper = Location().add(GoldLeaf(0x2C6))  # in the castle, spinning spikeball enemy
@@ -265,6 +268,7 @@ class World:
         self._addEntrance("d6_connector_entrance", d6_armos_island, d6_connector_right, None)
         self._addEntrance("d6_connector_exit", d6_entrance, d6_connector_left, None)
         self._addEntrance("d6", d6_entrance, None, FACE_KEY)
+        self._addEntranceRequirementExit("d6", None) # if exiting, you do not need to open the dungeon
 
         windfish_egg = Location().connect(swamp, POWER_BRACELET).connect(graveyard, POWER_BRACELET)
         windfish_egg.connect(graveyard, None, one_way=True) # Ledge jump
@@ -296,6 +300,7 @@ class World:
         d4_entrance = Location().connect(below_right_taltal, FLIPPERS)
         lower_right_taltal.connect(d4_entrance, AND(ANGLER_KEY, "ANGLER_KEYHOLE"), one_way=True)
         self._addEntrance("d4", d4_entrance, None, ANGLER_KEY)
+        self._addEntranceRequirementExit("d4", FLIPPERS) # if exiting, you can leave with flippers without opening the dungeon
         mambo = Location().connect(Location().add(Song(0x2FD)), AND(OCARINA, FLIPPERS))  # Manbo's Mambo
         self._addEntrance("mambo", d4_entrance, mambo, FLIPPERS) 
 
@@ -498,7 +503,7 @@ class World:
             ukuku_prairie.connect(bay_water, FEATHER, one_way=True) # jesus jump
             bay_water.connect(d5_entrance, FEATHER) # jesus jump into d5 entrance (wall clip), wall clip + jesus jump to get out
             
-            crow_gold_leaf.connect(castle_outside, AND(BOMB, OR(r.attack_no_bomb, POWER_BRACELET))) # bird on tree at left side kanalet, place a bomb against the tree and the crow flies off.
+            crow_gold_leaf.connect(castle_outside, AND(BOMB, OR(r.attack_hookshot_no_bomb, POWER_BRACELET))) # bird on tree at left side kanalet, place a bomb against the tree and the crow flies off.
             animal_village_bombcave_heartpiece.connect(animal_village_bombcave, PEGASUS_BOOTS) # boots bonk across bottom wall (both at entrance and in item room)
 
             d6_armos_island.connect(ukuku_prairie, FEATHER) # jesus jump (3 screen) from seashell mansion to armos island

--- a/logic/requirements.py
+++ b/logic/requirements.py
@@ -263,7 +263,7 @@ class RequirementsSettings:
             BOMB,  # D6 boss
             AND(OR(MAGIC_ROD, SWORD, HOOKSHOT), COUNT(SHIELD, 2)),  # D7 boss
             MAGIC_ROD,  # D8 boss
-            self.attack_no_bomb,  # D9 boss
+            self.attack_hookshot_no_bomb,  # D9 boss
         ]
         self.miniboss_requirements = {
             "ROLLING_BONES":    self.attack_hookshot,
@@ -272,7 +272,7 @@ class RequirementsSettings:
             "CUE_BALL":         SWORD,
             "GHOMA":            OR(BOW, HOOKSHOT),
             "SMASHER":          POWER_BRACELET,
-            "GRIM_CREEPER":     self.attack_no_bomb,
+            "GRIM_CREEPER":     self.attack_hookshot_no_bomb,
             "BLAINO":           SWORD,
             "AVALAUNCH":        self.attack_hookshot,
             "GIANT_BUZZ_BLOB":  MAGIC_POWDER,


### PR DESCRIPTION
d1: add bomb as option for hardhat beetles at the start
d2: add hookshot as option for first key chest surrounded by raised blocks by hitting switch in previous room
d3 glitched: fix superjump logic to raised_blocks_east where boots + feather was a valid combo without a way to deal with zols in room before
d3 hell: add boots superhops properly for both raised blocks chests
d7: split beamos horseheads from pre_boss in logic to properly require hookshot for pre_boss in harder logics
d7 hell: properly add boots superhops on ground floor, and to goomba jump to the boss staircase
d8: fix boss requirements to use bossdoor instead of entrance_up
color: remove weapon req for miniboss1, adjusted subsequent rooms where necessary
color hell: add shield for karakoro rooms
overworld: add dungeon entrance exits without dungeon key for entrance rando and relevant logic
(OW) Requirements: replace all attack_no_bomb with attack_hookshot_no_bomb in logic as they do the same