### PR TITLE
Improve json spoilers

### DIFF
--- a/main.py
+++ b/main.py
@@ -220,20 +220,21 @@ def main(mainargs=None):
             print("Cannot read spoiler log for race rom")
             sys.exit(1)
 
+    userSeed = None
     if args.seed:
         try:
-            args.seed = binascii.unhexlify(args.seed)
+            userSeed = binascii.unhexlify(args.seed)
         except binascii.Error:
-            args.seed = args.seed.encode("ascii")
+            userSeed = args.seed.encode("ascii")
 
     retry_count = 0
     while True:
         try:
-            r = randomizer.Randomizer(args, seed=args.seed)
+            r = randomizer.Randomizer(args, seed=userSeed)
             seed = binascii.hexlify(r.seed).decode("ascii").upper()
             break
         except randomizer.Error:
-            if args.seed is not None:
+            if userSeed is not None:
                 print("Specified seed does not produce a valid result.")
                 sys.exit(1)
             retry_count += 1

--- a/spoilerLog.py
+++ b/spoilerLog.py
@@ -161,7 +161,8 @@ class SpoilerLog:
                 {entrance: target for entrance, target in self.logic.world_setup.entrance_mapping.items() if entrance != target}
                 if isinstance(self.logic, logic.Logic) else [
                     {entrance: target for entrance, target in world.world_setup.entrance_mapping.items() if entrance != target} for world in self.logic.worlds
-                ]
+                ],
+            "seed": self.seed
         }, indent="  ")
 
         if zipFile:


### PR DESCRIPTION
* fixes a bug where a player-provided seed would crash the json serializer due to being a bytes object
* adds the seed to the json spoiler log, so it isn't only in the filename
