### PR TITLE
docs: overhaul for v0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ See https://daid.github.io/LADXR/
 
 ## Usage
 
-The only requirement to use is python3, and a proper Links Awakening ROM.
+The only requirements are: to use python3, and the v1.0 ROM for Links Awakening DX.
+
+The proper SHA-1 for the rom is `d90ac17e9bf17b6c61624ad9f05447bdb5efc01a`.
 
 Basic usage:
 `python3 main.py zelda.gbc`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ See https://daid.github.io/LADXR/
 
 ## Usage
 
-The only requirements are: to use python3, and the v1.0 ROM for Links Awakening DX.
+The only requirements are: to use python3, and the English v1.0 ROM for Links Awakening DX.
 
 The proper SHA-1 for the rom is `d90ac17e9bf17b6c61624ad9f05447bdb5efc01a`.
 

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mini.css/3.0.1/mini-default.min.css"> -->
+<link rel="stylesheet" href="style.css">
 <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -12,8 +12,12 @@
 <p>If you are looking for a cartridge dumper, <a href="https://www.gbxcart.com/">GBxCart RW</a> is relatively cheap and known to be good and safe.</p>
 
 <h3>How do I know that I have the correct version of the ROM?</h3>
+<p>If you know how to use hashes, the correct rom is the Link's Awakening DX English (US) revision 0 rom. The SHA-1 for it is "d90ac17e9bf17b6c61624ad9f05447bdb5efc01a".</p>
+<br />
+<p>If the above was greek to you, please read the below section.</p>
+<br />
 <p>First off, you need an english version. That is easy to see. Next, you need the 1.0 version. The quickest way to check this is in the library (you know, where the kids are outside playing with a ball)</p>
-<p>In this library, if the book on top of the bookshelve has a shadow, it's 1.0, else it is a newer version and you have the wrong version. If there is no book you have the classic gameboy version, you need the DX color version.</p>
+<p>In this library, if the book on top of the bookshelf has a shadow, it's 1.0, else it is a newer version, and you have the wrong version. If there is no book, you have the classic GameBoy version, you need the DX color version.</p>
 
 <h3>Why do I get a screen with BAD EMU?</h3>
 <p>Stop using VisualBoyAdvance. It's a horrible emulator, it even causes random bugs in the vanilla game. Use:</p>
@@ -25,12 +29,12 @@
 </ul>
 
 <h3>Do I need to use glitches/bugs?</h3>
-<p>No, all skill levels are welcome. The default settings can require that you do a few obsecure things, like killing enemies with bombs. And dropping down one way ledges. There is a casual logic setting which removes these requirements and makes it easier.</p>
+<p>No, all skill levels are welcome. The default settings can require that you do a few obscure things, like killing enemies with bombs, and dropping down one way ledges. There is a casual logic setting that will remove these requirements and make it easier.</p>
 <p>It is expected that you know where all the <a href="https://www.zeldadungeon.net/wiki/Link%27s_Awakening_Heart_Pieces_(Game_Boy)">heart pieces</a> are hidden, and the <a href="https://www.zeldadungeon.net/wiki/Link%27s_Awakening_Secret_Seashells_(Game_Boy)">hidden secret seashells</a>.</p>
 <p>There is a setting for glitched logic, which will require the use of glitches to progress. A full list of these is maintained at the <a href="https://discord.gg/XTw7X2G">discord</a> channel.</p>
 
 <h3>I found an issue?</h3>
-<p>It is possible. Reach out on <a href="https://discord.gg/XTw7X2G">discord</a>, or at <a href="https://github.com/daid/LADXR/issues">github issue tracker</a></p>
+<p>It is possible. Reach out on <a href="https://discord.gg/XTw7X2G">discord</a>, or at the <a href="https://github.com/daid/LADXR/issues">github issue tracker</a>.</p>
 
 <h3>I found both red and blue tunic?</h3>
 <p>That is by design, you can switch tunic between your options at a phonebooth. If you have an tunic color override, you can see your current tunic in the [SELECT] menu inside your inventory screen.</p>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -1,6 +1,8 @@
+<!DOCTYPE html>
 <html>
 <head>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mini.css/3.0.1/mini-default.min.css">
+<!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mini.css/3.0.1/mini-default.min.css"> -->
+<link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
@@ -8,16 +10,16 @@
 <h1>LADXR: Frequently asked questions</h1>
 
 <h3>How do I get the right ROM?</h3>
-<p>For legal reasons, we can only tell you to get an official cartridge and dump the rom from that with a cartridge dumper.</p>
-<p>If you are looking for a cartridge dumper, <a href="https://www.gbxcart.com/">GBxCart RW</a> is relatively cheap and known to be good and safe.</p>
+<p>For legal reasons, we can only tell you to get an official cartridge, and dump the rom from an official cart with a cartridge dumper.</p>
+<p>If you are looking for a cartridge dumper, <a href="https://www.gbxcart.com/">GBxCart RW</a> is relatively cheap, and known to be good & safe.</p>
 
 <h3>How do I know that I have the correct version of the ROM?</h3>
-<p>If you know how to use hashes, the correct rom is the Link's Awakening DX English (US) revision 0 rom. The SHA-1 for it is "d90ac17e9bf17b6c61624ad9f05447bdb5efc01a".</p>
+<p>If you know how to use hashes, you need the English v1.0 ROM for Links Awakening DX. The SHA-1 for it is "d90ac17e9bf17b6c61624ad9f05447bdb5efc01a".</p>
 <br />
 <p>If the above was greek to you, please read the below section.</p>
 <br />
-<p>First off, you need an english version. That is easy to see. Next, you need the 1.0 version. The quickest way to check this is in the library (you know, where the kids are outside playing with a ball)</p>
-<p>In this library, if the book on top of the bookshelf has a shadow, it's 1.0, else it is a newer version, and you have the wrong version. If there is no book, you have the classic GameBoy version, you need the DX color version.</p>
+<p>First off, it needs to be English. Next, you need it on v1.0. The quickest way to check this is in the library (below Mabe well/the forest entrance).</p>
+<p>In this library, if the book on top of the bookshelf has a shadow, it's v1.0; else it is a newer version, and you have the wrong version. If there is no book, you have the GameBoy version, you need the DX (GameBoy Color) version.</p>
 
 <h3>Why do I get a screen with BAD EMU?</h3>
 <p>Stop using VisualBoyAdvance. It's a horrible emulator, it even causes random bugs in the vanilla game. Use:</p>
@@ -26,6 +28,7 @@
 <li><a href="https://sameboy.github.io/">SameBoy</a>: Very accurate emulator. Great on MacOS. The UI is less friendly on Windows/Linux.</li>
 <li><a href="https://emulicious.net/">Emulicious</a>: Accurate, lots of features.</li>
 <li><a href="https://www.retroarch.com/">RetroArch</a>: If you use Android there are not many options. RetroArch with the SameBoy core is your best option. Most emulators on Android are horrible.</li>
+<li><a href="https://mgba.io/">mGBA</a>: <em>Accurate enough</em> GBC emulation to not cause problems. Use something else if you can.</li>
 </ul>
 
 <h3>Do I need to use glitches/bugs?</h3>
@@ -34,17 +37,16 @@
 <p>There is a setting for glitched logic, which will require the use of glitches to progress. A full list of these is maintained at the <a href="https://discord.gg/XTw7X2G">discord</a> channel.</p>
 
 <h3>I found an issue?</h3>
-<p>It is possible. Reach out on <a href="https://discord.gg/XTw7X2G">discord</a>, or at the <a href="https://github.com/daid/LADXR/issues">github issue tracker</a>.</p>
+<p>It is possible. Reach out on <a href="https://discord.gg/XTw7X2G">discord</a>, or at the <a href="https://github.com/daid/LADXR/issues">Github issue tracker</a>.</p>
 
 <h3>I found both red and blue tunic?</h3>
-<p>That is by design, you can switch tunic between your options at a phonebooth. If you have an tunic color override, you can see your current tunic in the [SELECT] menu inside your inventory screen.</p>
+<p>That is by design, you can switch tunic between your options at a phone booth. If you have an tunic color override, you can see your current tunic in the [SELECT] menu inside your inventory screen.</p>
 
 <h3>The rooster is not working?</h3>
-<p>Rooster wasn't available pre-v10, as it left you after completing D7 it was possible to lock yourself out of the Bird Key location. To prevent this, the Bird Key cave is modified to be accessible with a L2 Power Bracelet.</p>
+<p>Rooster wasn't available pre-v10, as it had left you after completing D7: making it possible to lock yourself out of the Bird Key location. To prevent this, the Bird Key cave is modified to be accessible with a L2 Power Bracelet, and Rooster is a permanent item.</p>
 
 <h3>What is up with the trade quest?</h3>
-<p>The trade quest, with the magnifying lens as reward, is completely optional. You don't ever need to do it. The book for the egg path can always be read. But, more important, if you never read the book, the path is always LLURRULU. This path is vanilla behaviour.</p>
-<p>The reason for having the trade quest out of randomization is because the items for this quest are not different items, it is just a counter. And just randomizing the reward would put a large boring task into your todo list. So this streamlines the experience a bit.</p>
+<p>By default, each member of the trade quest will give you an item if you show them what they want. They are decoupled from eachother, and you can have all of the items at the same time.</p>
 
 <h3>I found a single arrow?</h3>
 <p>It's a wink towards the <a href="https://alttpr.com/">A Link to the Past randomizer</a>, where there is also a single arrow chest shuffled with the items.</p>
@@ -53,10 +55,10 @@
 <p>Drop in our <a href="https://discord.gg/XTw7X2G">discord</a>. These options are for really advanced players, and require a lot of in-depth game knowledge. Don't use this option unless you really know what you are doing.</p>
 
 <h3>What is this Multiworld I hear about?</h3>
-<p>It allows two or more people to play together, items are shuffled between multiple players games and you will find another persons items. The setup is complex and requires a specific emulator. As always, drop by <a href="https://discord.gg/XTw7X2G">discord</a>. We can help you out there or even play with you.</p>
+<p>It allows two or more people to play together: items are shuffled between multiple players' games, and you will find another persons' items. The setup is complex and requires a specific emulator. As always, drop by <a href="https://discord.gg/XTw7X2G">discord</a>. We can help you out there, or even play with you.</p>
 
 <h3>How do I make custom graphics?</h3>
-<p>Changing the graphics requires editing the <a href="https://github.com/daid/LADXR/raw/master/gfx/template.png">graphics template</a>. You can use this for the "custom..." option in the graphics selection to load the modified file.</p>
+<p>Changing the graphics requires editing the <a href="https://github.com/daid/LADXR/raw/master/gfx/template.png">graphics template</a>. You can use this for the "Custom..." option in the graphics selection to load the modified file.</p>
 
 </body>
 </html>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -36,14 +36,14 @@
 <p>That is by design, you can switch tunic between your options at a phonebooth. If you have an tunic color override, you can see your current tunic in the [SELECT] menu inside your inventory screen.</p>
 
 <h3>The rooster is not working?</h3>
-<p>Rooster isn't available, as it leaves you after completing D7 it would be possible to lock yourself out of the bird key location. Instead, the bird key cave is modified to be accessible with a L2 Power Bracelet.</p>
+<p>Rooster wasn't available pre-v10, as it left you after completing D7 it was possible to lock yourself out of the Bird Key location. To prevent this, the Bird Key cave is modified to be accessible with a L2 Power Bracelet.</p>
 
 <h3>What is up with the trade quest?</h3>
 <p>The trade quest, with the magnifying lens as reward, is completely optional. You don't ever need to do it. The book for the egg path can always be read. But, more important, if you never read the book, the path is always LLURRULU. This path is vanilla behaviour.</p>
 <p>The reason for having the trade quest out of randomization is because the items for this quest are not different items, it is just a counter. And just randomizing the reward would put a large boring task into your todo list. So this streamlines the experience a bit.</p>
 
 <h3>I found a single arrow?</h3>
-<p>It's a wink towards the A link to the past randomizer, where there is also a single arrow chest shuffled with the items.</p>
+<p>It's a wink towards the <a href="https://alttpr.com/">A Link to the Past randomizer</a>, where there is also a single arrow chest shuffled with the items.</p>
 
 <h3>Hard/Glitched/Hell logic is impossible!</h3>
 <p>Drop in our <a href="https://discord.gg/XTw7X2G">discord</a>. These options are for really advanced players, and require a lot of in-depth game knowledge. Don't use this option unless you really know what you are doing.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mini.css/3.0.1/mini-default.min.css"> -->
+<link rel="stylesheet" href="style.css">
 <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,11 +6,11 @@
 </head>
 <body>
 
-<h1>LADXR: Legend of Zelda: Link's Awakening DX - Randomizer</h1>
+<h1>LADXR: The Legend of Zelda: Link's Awakening DX - Randomizer</h1>
 
 <h2>What is this?</h2>
 <ul>
-<p>This is a randomizer for the Game Boy Color game The Legend of Zelda: Link's Awakening DX</p>
+<p>This is a randomizer for the North American revision 0 ROM of "The Legend of Zelda: Link's Awakening DX".</p>
 <p>What does this do? It changes the locations of items in the game to give a new way to play the game.</p>
 <p>It ensures the game is still beatable, by checking if all locations can still be reached. But no guarantee that you progress from Dungeon to Dungeon, you will have to find your own path.</p>
 <p>The goal of this randomizer is to create a new experience, which does not show any glitches or bugs (except when you use a bug/glitch yourself). Normal gameplay should not introduce any bugs, and it can be experienced like the normal game.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,6 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mini.css/3.0.1/mini-default.min.css">
+<!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mini.css/3.0.1/mini-default.min.css"> -->
 <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
@@ -9,18 +10,17 @@
 <h1>LADXR: The Legend of Zelda: Link's Awakening DX - Randomizer</h1>
 
 <h2>What is this?</h2>
+<p>LADXR is an item (and entrance) randomizer for the North American/English (revision-0/v1.0) ROM of "The Legend of Zelda: Link's Awakening DX".</p>
+<p><em>What does this do?</em> It changes the locations of items in order to provide a new experience to the game.</p>
+<p>It ensures the game is still beatable by checking if all locations can still be reached, but progress will (usually) not be linear: you will have to find your own path.</p>
+<p>The goal of this randomizer is to create a new experience, both glitchless and bugless (except those caused by the player). Normal gameplay should not introduce any bugs, and it can be experienced like the normal game.</p>
+
+<h2>Feature list:</h2>
 <ul>
-<p>This is a randomizer for the North American revision 0 ROM of "The Legend of Zelda: Link's Awakening DX".</p>
-<p>What does this do? It changes the locations of items in the game to give a new way to play the game.</p>
-<p>It ensures the game is still beatable, by checking if all locations can still be reached. But no guarantee that you progress from Dungeon to Dungeon, you will have to find your own path.</p>
-<p>The goal of this randomizer is to create a new experience, which does not show any glitches or bugs (except when you use a bug/glitch yourself). Normal gameplay should not introduce any bugs, and it can be experienced like the normal game.</p>
-<p>Feature list:
-<li>All contents in chests are shuffled.</li>
-<li>The shield given by Tarin is shuffled.</li>
-<li>Heart Pieces and seashells not found in chests can be shuffled optionally.</li>
-<li>Small Keys, Nightmare Keys, Maps, Compasses, and Stone Beaks are shuffled within their respective dungeons. Keysanity will allow them to be shuffled anywhere in the game.</li>
+<li>Nearly every item is able to be shuffled, depending on your selected settings.</li>
+<li>Dungeon items are shuffled within their respective dungeon by default, but can be included with the rest of the pool (via keysanity, and the such).</li>
 <li>Dungeon keys (Tail Key, Angler Key, Face Key, Bird Key and Slime Key) and the Golden Leaves are also shuffled into the pool of items.</li>
-<li>Completing the trading sequence is not required to beat the game. (The book that tells you the path through the Wind Fish's Egg is readable without the Magnifying Lens) This also means that taking Marin on a date isn't required, either.</li>
+<li>The trading sequence and the date with Marin are now optional. Each part of the trading sequence will give you an item if you show them what they need.</li>
 </ul>
 <p>See the <a href="faq.html">FAQ</a></p>
 <p>See the <a href="tips.html">Tips</a></p>
@@ -28,11 +28,11 @@
 <h2>Play</h2>
 
 <p>You can use the following webpages to generate a custom randomized ROM for you.</p>
-<p><a href="http://ladxr.daid.eu/latest/"><strong>Latest: </strong>Latest greatest version, can change at any moment and might be unstable, but most of the time works great.</a></p>
-<p><a href="http://ladxr.daid.eu/v10/"><strong>V0.10: </strong>Current stable version. Fixed all the issues found in v0.9 and very stable, adds a few options not available in 0.9</a></p>
-<p><a href="http://ladxr.daid.eu/v09/"><strong>V0.9: </strong>Long time in the work compared to V0.8, many new options, newer web interface. Recommended. Entrance randomization contains bugs and should be avoided.</a></p>
-<p><a href="http://ladxr.daid.eu/v08/"><strong>V0.8: </strong>Combining boss shuffle with heart container randomization is buggy. Various small logic bugs, less options then 0.9.</a></p>
-<p><a href="http://ladxr.daid.eu/v07/"><strong>V0.7: </strong>Older version, few small logic bugs, much less options.</a></p>
+<p><a href="http://ladxr.daid.eu/latest/"><strong>Latest: </strong>The latest and greatest version, fresh off of the master branch. Can change at any moment, and may be unstable, but most of the time it works great.</a></p>
+<p><a href="http://ladxr.daid.eu/v10/"><strong>V0.10: </strong>Current stable version. Many bugfixes from v0.9, also adds a few more options.</a></p>
+<p><a href="http://ladxr.daid.eu/v09/"><strong>V0.9: </strong>Long time in the work compared to V0.8, many new options, newer web interface. Entrance randomization contains bugs, and should be avoided.</a></p>
+<p><a href="http://ladxr.daid.eu/v08/"><strong>V0.8: </strong>Combining boss shuffle with heart container randomization is buggy. Various small logic bugs, less options than v0.9.</a></p>
+<p><a href="http://ladxr.daid.eu/v07/"><strong>V0.7: </strong>A few small logic bugs, far less options.</a></p>
 <p><a href="http://ladxr.daid.eu/v06/"><strong>V0.6: </strong>Whole bunch of small bugs, softlocking due to bad key logic is possible, many newer features not available.</a></p>
 <p><a href="http://ladxr.daid.eu/v05/"><strong>V0.5: </strong>Contains a few logic bugs, newer versions are recommended.</a></p>
 <p>(Older versions are too unstable to be useful and are not recommended, as seed generation was not stable)</p>
@@ -40,7 +40,7 @@
 <h2>Community</h2>
 
 <p>Drop by on <a href="https://discord.gg/XTw7X2G">discord</a> for a chat, or to join in on races!</p>
-<p>Report issues/bugs on <a href="https://discord.gg/XTw7X2G">discord</a>, or at <a href="https://github.com/daid/LADXR/issues">github issue tracker</a></p>
+<p>Report issues/bugs on <a href="https://discord.gg/XTw7X2G">discord</a>, or at the <a href="https://github.com/daid/LADXR/issues">github issue tracker</a></p>
 <p>Visit <a href="https://sites.google.com/view/z4randomizer">here</a> for another Links Awakening Randomizer called Z4R, which has a different focus and gives different playstyle options. Both are cool! We use the same discord server.</p>
 <p>New to the game?  We recommend using a tracker!</p>
 <ul>
@@ -49,7 +49,7 @@
 </ul>
 <h2>Development</h2>
 
-<p>Source code is available at: <a href="https://github.com/daid/LADXR/">Source code</a>. If you want to contribute, that can be done in many ways, including updating documentation, logic. Or even just bug reports!</p>
+<p>Source code is available at <a href="https://github.com/daid/LADXR/">Github</a>. If you want to contribute, that can be done in many ways, including updating documentation, logic, or even just bug reports!</p>
 
 </body>
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,2339 @@
+/*
+This is https://cdnjs.cloudflare.com/ajax/libs/mini.css/3.0.1/mini-default.min.css, re-formatted, and external links removed.
+*/
+
+:root {
+    --fore-color: #111;
+    --secondary-fore-color: #444;
+    --back-color: #f8f8f8;
+    --secondary-back-color: #f0f0f0;
+    --blockquote-color: #f57c00;
+    --pre-color: #1565c0;
+    --border-color: #aaa;
+    --secondary-border-color: #ddd;
+    --heading-ratio: 1.19;
+    --universal-margin: .5rem;
+    --universal-padding: .5rem;
+    --universal-border-radius: .125rem;
+    --a-link-color: #0277bd;
+    --a-visited-color: #01579b
+}
+
+html {
+    font-size: 16px
+}
+
+a,
+b,
+del,
+em,
+i,
+ins,
+q,
+span,
+strong,
+u {
+    font-size: 1em
+}
+
+html,
+* {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Helvetica Neue", Helvetica, sans-serif;
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%
+}
+
+* {
+    font-size: 1rem
+}
+
+body {
+    margin: 0;
+    color: var(--fore-color);
+    background: var(--back-color)
+}
+
+details {
+    display: block
+}
+
+summary {
+    display: list-item
+}
+
+abbr[title] {
+    border-bottom: none;
+    text-decoration: underline dotted
+}
+
+input {
+    overflow: visible
+}
+
+img {
+    max-width: 100%;
+    height: auto
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    line-height: 1.2;
+    margin: calc(1.5 * var(--universal-margin)) var(--universal-margin);
+    font-weight: 500
+}
+
+h1 small,
+h2 small,
+h3 small,
+h4 small,
+h5 small,
+h6 small {
+    color: var(--secondary-fore-color);
+    display: block;
+    margin-top: -.25rem
+}
+
+h1 {
+    font-size: calc(1rem * var(--heading-ratio) * var(--heading-ratio) * var(--heading-ratio) * var(--heading-ratio))
+}
+
+h2 {
+    font-size: calc(1rem * var(--heading-ratio) * var(--heading-ratio) * var(--heading-ratio))
+}
+
+h3 {
+    font-size: calc(1rem * var(--heading-ratio) * var(--heading-ratio))
+}
+
+h4 {
+    font-size: calc(1rem * var(--heading-ratio))
+}
+
+h5 {
+    font-size: 1rem
+}
+
+h6 {
+    font-size: calc(1rem / var(--heading-ratio))
+}
+
+p {
+    margin: var(--universal-margin)
+}
+
+ol,
+ul {
+    margin: var(--universal-margin);
+    padding-left: calc(2 * var(--universal-margin))
+}
+
+b,
+strong {
+    font-weight: 700
+}
+
+hr {
+    box-sizing: content-box;
+    border: 0;
+    line-height: 1.25em;
+    margin: var(--universal-margin);
+    height: .0625rem;
+    background: linear-gradient(to right, transparent, var(--border-color) 20%, var(--border-color) 80%, transparent)
+}
+
+blockquote {
+    display: block;
+    position: relative;
+    font-style: italic;
+    color: var(--secondary-fore-color);
+    margin: var(--universal-margin);
+    padding: calc(3 * var(--universal-padding));
+    border: .0625rem solid var(--secondary-border-color);
+    border-left: .375rem solid var(--blockquote-color);
+    border-radius: 0 var(--universal-border-radius) var(--universal-border-radius) 0
+}
+
+blockquote:before {
+    position: absolute;
+    top: calc(0rem - var(--universal-padding));
+    left: 0;
+    font-family: sans-serif;
+    font-size: 3rem;
+    font-weight: 700;
+    content: "\201c";
+    color: var(--blockquote-color)
+}
+
+blockquote[cite]:after {
+    font-style: normal;
+    font-size: .75em;
+    font-weight: 700;
+    content: "\a—  " attr(cite);
+    white-space: pre
+}
+
+code,
+kbd,
+pre,
+samp {
+    font-family: Menlo, Consolas, monospace;
+    font-size: .85em
+}
+
+code {
+    background: var(--secondary-back-color);
+    border-radius: var(--universal-border-radius);
+    padding: calc(var(--universal-padding) / 4) calc(var(--universal-padding) / 2)
+}
+
+kbd {
+    background: var(--fore-color);
+    color: var(--back-color);
+    border-radius: var(--universal-border-radius);
+    padding: calc(var(--universal-padding) / 4) calc(var(--universal-padding) / 2)
+}
+
+pre {
+    overflow: auto;
+    background: var(--secondary-back-color);
+    padding: calc(1.5 * var(--universal-padding));
+    margin: var(--universal-margin);
+    border: .0625rem solid var(--secondary-border-color);
+    border-left: .25rem solid var(--pre-color);
+    border-radius: 0 var(--universal-border-radius) var(--universal-border-radius) 0
+}
+
+sup,
+sub,
+code,
+kbd {
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline
+}
+
+small,
+sup,
+sub,
+figcaption {
+    font-size: .75em
+}
+
+sup {
+    top: -.5em
+}
+
+sub {
+    bottom: -.25em
+}
+
+figure {
+    margin: var(--universal-margin)
+}
+
+figcaption {
+    color: var(--secondary-fore-color)
+}
+
+a {
+    text-decoration: none
+}
+
+a:link {
+    color: var(--a-link-color)
+}
+
+a:visited {
+    color: var(--a-visited-color)
+}
+
+a:hover,
+a:focus {
+    text-decoration: underline
+}
+
+.container {
+    margin: 0 auto;
+    padding: 0 calc(1.5 * var(--universal-padding))
+}
+
+.row {
+    box-sizing: border-box;
+    display: flex;
+    flex: 0 1 auto;
+    flex-flow: row wrap
+}
+
+.col-sm,
+[class^='col-sm-'],
+[class^='col-sm-offset-'],
+.row[class*='cols-sm-']>* {
+    box-sizing: border-box;
+    flex: 0 0 auto;
+    padding: 0 calc(var(--universal-padding) / 2)
+}
+
+.col-sm,
+.row.cols-sm>* {
+    max-width: 100%;
+    flex-grow: 1;
+    flex-basis: 0
+}
+
+.col-sm-1,
+.row.cols-sm-1>* {
+    max-width: 8.33333%;
+    flex-basis: 8.33333%
+}
+
+.col-sm-offset-0 {
+    margin-left: 0
+}
+
+.col-sm-2,
+.row.cols-sm-2>* {
+    max-width: 16.66667%;
+    flex-basis: 16.66667%
+}
+
+.col-sm-offset-1 {
+    margin-left: 8.33333%
+}
+
+.col-sm-3,
+.row.cols-sm-3>* {
+    max-width: 25%;
+    flex-basis: 25%
+}
+
+.col-sm-offset-2 {
+    margin-left: 16.66667%
+}
+
+.col-sm-4,
+.row.cols-sm-4>* {
+    max-width: 33.33333%;
+    flex-basis: 33.33333%
+}
+
+.col-sm-offset-3 {
+    margin-left: 25%
+}
+
+.col-sm-5,
+.row.cols-sm-5>* {
+    max-width: 41.66667%;
+    flex-basis: 41.66667%
+}
+
+.col-sm-offset-4 {
+    margin-left: 33.33333%
+}
+
+.col-sm-6,
+.row.cols-sm-6>* {
+    max-width: 50%;
+    flex-basis: 50%
+}
+
+.col-sm-offset-5 {
+    margin-left: 41.66667%
+}
+
+.col-sm-7,
+.row.cols-sm-7>* {
+    max-width: 58.33333%;
+    flex-basis: 58.33333%
+}
+
+.col-sm-offset-6 {
+    margin-left: 50%
+}
+
+.col-sm-8,
+.row.cols-sm-8>* {
+    max-width: 66.66667%;
+    flex-basis: 66.66667%
+}
+
+.col-sm-offset-7 {
+    margin-left: 58.33333%
+}
+
+.col-sm-9,
+.row.cols-sm-9>* {
+    max-width: 75%;
+    flex-basis: 75%
+}
+
+.col-sm-offset-8 {
+    margin-left: 66.66667%
+}
+
+.col-sm-10,
+.row.cols-sm-10>* {
+    max-width: 83.33333%;
+    flex-basis: 83.33333%
+}
+
+.col-sm-offset-9 {
+    margin-left: 75%
+}
+
+.col-sm-11,
+.row.cols-sm-11>* {
+    max-width: 91.66667%;
+    flex-basis: 91.66667%
+}
+
+.col-sm-offset-10 {
+    margin-left: 83.33333%
+}
+
+.col-sm-12,
+.row.cols-sm-12>* {
+    max-width: 100%;
+    flex-basis: 100%
+}
+
+.col-sm-offset-11 {
+    margin-left: 91.66667%
+}
+
+.col-sm-normal {
+    order: initial
+}
+
+.col-sm-first {
+    order: -999
+}
+
+.col-sm-last {
+    order: 999
+}
+
+@media screen and (min-width: 768px) {
+
+    .col-md,
+    [class^='col-md-'],
+    [class^='col-md-offset-'],
+    .row[class*='cols-md-']>* {
+        box-sizing: border-box;
+        flex: 0 0 auto;
+        padding: 0 calc(var(--universal-padding) / 2)
+    }
+
+    .col-md,
+    .row.cols-md>* {
+        max-width: 100%;
+        flex-grow: 1;
+        flex-basis: 0
+    }
+
+    .col-md-1,
+    .row.cols-md-1>* {
+        max-width: 8.33333%;
+        flex-basis: 8.33333%
+    }
+
+    .col-md-offset-0 {
+        margin-left: 0
+    }
+
+    .col-md-2,
+    .row.cols-md-2>* {
+        max-width: 16.66667%;
+        flex-basis: 16.66667%
+    }
+
+    .col-md-offset-1 {
+        margin-left: 8.33333%
+    }
+
+    .col-md-3,
+    .row.cols-md-3>* {
+        max-width: 25%;
+        flex-basis: 25%
+    }
+
+    .col-md-offset-2 {
+        margin-left: 16.66667%
+    }
+
+    .col-md-4,
+    .row.cols-md-4>* {
+        max-width: 33.33333%;
+        flex-basis: 33.33333%
+    }
+
+    .col-md-offset-3 {
+        margin-left: 25%
+    }
+
+    .col-md-5,
+    .row.cols-md-5>* {
+        max-width: 41.66667%;
+        flex-basis: 41.66667%
+    }
+
+    .col-md-offset-4 {
+        margin-left: 33.33333%
+    }
+
+    .col-md-6,
+    .row.cols-md-6>* {
+        max-width: 50%;
+        flex-basis: 50%
+    }
+
+    .col-md-offset-5 {
+        margin-left: 41.66667%
+    }
+
+    .col-md-7,
+    .row.cols-md-7>* {
+        max-width: 58.33333%;
+        flex-basis: 58.33333%
+    }
+
+    .col-md-offset-6 {
+        margin-left: 50%
+    }
+
+    .col-md-8,
+    .row.cols-md-8>* {
+        max-width: 66.66667%;
+        flex-basis: 66.66667%
+    }
+
+    .col-md-offset-7 {
+        margin-left: 58.33333%
+    }
+
+    .col-md-9,
+    .row.cols-md-9>* {
+        max-width: 75%;
+        flex-basis: 75%
+    }
+
+    .col-md-offset-8 {
+        margin-left: 66.66667%
+    }
+
+    .col-md-10,
+    .row.cols-md-10>* {
+        max-width: 83.33333%;
+        flex-basis: 83.33333%
+    }
+
+    .col-md-offset-9 {
+        margin-left: 75%
+    }
+
+    .col-md-11,
+    .row.cols-md-11>* {
+        max-width: 91.66667%;
+        flex-basis: 91.66667%
+    }
+
+    .col-md-offset-10 {
+        margin-left: 83.33333%
+    }
+
+    .col-md-12,
+    .row.cols-md-12>* {
+        max-width: 100%;
+        flex-basis: 100%
+    }
+
+    .col-md-offset-11 {
+        margin-left: 91.66667%
+    }
+
+    .col-md-normal {
+        order: initial
+    }
+
+    .col-md-first {
+        order: -999
+    }
+
+    .col-md-last {
+        order: 999
+    }
+}
+
+@media screen and (min-width: 1280px) {
+
+    .col-lg,
+    [class^='col-lg-'],
+    [class^='col-lg-offset-'],
+    .row[class*='cols-lg-']>* {
+        box-sizing: border-box;
+        flex: 0 0 auto;
+        padding: 0 calc(var(--universal-padding) / 2)
+    }
+
+    .col-lg,
+    .row.cols-lg>* {
+        max-width: 100%;
+        flex-grow: 1;
+        flex-basis: 0
+    }
+
+    .col-lg-1,
+    .row.cols-lg-1>* {
+        max-width: 8.33333%;
+        flex-basis: 8.33333%
+    }
+
+    .col-lg-offset-0 {
+        margin-left: 0
+    }
+
+    .col-lg-2,
+    .row.cols-lg-2>* {
+        max-width: 16.66667%;
+        flex-basis: 16.66667%
+    }
+
+    .col-lg-offset-1 {
+        margin-left: 8.33333%
+    }
+
+    .col-lg-3,
+    .row.cols-lg-3>* {
+        max-width: 25%;
+        flex-basis: 25%
+    }
+
+    .col-lg-offset-2 {
+        margin-left: 16.66667%
+    }
+
+    .col-lg-4,
+    .row.cols-lg-4>* {
+        max-width: 33.33333%;
+        flex-basis: 33.33333%
+    }
+
+    .col-lg-offset-3 {
+        margin-left: 25%
+    }
+
+    .col-lg-5,
+    .row.cols-lg-5>* {
+        max-width: 41.66667%;
+        flex-basis: 41.66667%
+    }
+
+    .col-lg-offset-4 {
+        margin-left: 33.33333%
+    }
+
+    .col-lg-6,
+    .row.cols-lg-6>* {
+        max-width: 50%;
+        flex-basis: 50%
+    }
+
+    .col-lg-offset-5 {
+        margin-left: 41.66667%
+    }
+
+    .col-lg-7,
+    .row.cols-lg-7>* {
+        max-width: 58.33333%;
+        flex-basis: 58.33333%
+    }
+
+    .col-lg-offset-6 {
+        margin-left: 50%
+    }
+
+    .col-lg-8,
+    .row.cols-lg-8>* {
+        max-width: 66.66667%;
+        flex-basis: 66.66667%
+    }
+
+    .col-lg-offset-7 {
+        margin-left: 58.33333%
+    }
+
+    .col-lg-9,
+    .row.cols-lg-9>* {
+        max-width: 75%;
+        flex-basis: 75%
+    }
+
+    .col-lg-offset-8 {
+        margin-left: 66.66667%
+    }
+
+    .col-lg-10,
+    .row.cols-lg-10>* {
+        max-width: 83.33333%;
+        flex-basis: 83.33333%
+    }
+
+    .col-lg-offset-9 {
+        margin-left: 75%
+    }
+
+    .col-lg-11,
+    .row.cols-lg-11>* {
+        max-width: 91.66667%;
+        flex-basis: 91.66667%
+    }
+
+    .col-lg-offset-10 {
+        margin-left: 83.33333%
+    }
+
+    .col-lg-12,
+    .row.cols-lg-12>* {
+        max-width: 100%;
+        flex-basis: 100%
+    }
+
+    .col-lg-offset-11 {
+        margin-left: 91.66667%
+    }
+
+    .col-lg-normal {
+        order: initial
+    }
+
+    .col-lg-first {
+        order: -999
+    }
+
+    .col-lg-last {
+        order: 999
+    }
+}
+
+:root {
+    --card-back-color: #f8f8f8;
+    --card-fore-color: #111;
+    --card-border-color: #ddd
+}
+
+.card {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-self: center;
+    position: relative;
+    width: 100%;
+    background: var(--card-back-color);
+    color: var(--card-fore-color);
+    border: .0625rem solid var(--card-border-color);
+    border-radius: var(--universal-border-radius);
+    margin: var(--universal-margin);
+    overflow: hidden
+}
+
+@media screen and (min-width: 320px) {
+    .card {
+        max-width: 320px
+    }
+}
+
+.card>.section {
+    background: var(--card-back-color);
+    color: var(--card-fore-color);
+    box-sizing: border-box;
+    margin: 0;
+    border: 0;
+    border-radius: 0;
+    border-bottom: .0625rem solid var(--card-border-color);
+    padding: var(--universal-padding);
+    width: 100%
+}
+
+.card>.section.media {
+    height: 200px;
+    padding: 0;
+    -o-object-fit: cover;
+    object-fit: cover
+}
+
+.card>.section:last-child {
+    border-bottom: 0
+}
+
+@media screen and (min-width: 240px) {
+    .card.small {
+        max-width: 240px
+    }
+}
+
+@media screen and (min-width: 480px) {
+    .card.large {
+        max-width: 480px
+    }
+}
+
+.card.fluid {
+    max-width: 100%;
+    width: auto
+}
+
+.card.warning {
+    --card-back-color: #ffca28;
+    --card-border-color: #e8b825
+}
+
+.card.error {
+    --card-back-color: #b71c1c;
+    --card-fore-color: #f8f8f8;
+    --card-border-color: #a71a1a
+}
+
+.card>.section.dark {
+    --card-back-color: #e0e0e0
+}
+
+.card>.section.double-padded {
+    padding: calc(1.5 * var(--universal-padding))
+}
+
+:root {
+    --form-back-color: #f0f0f0;
+    --form-fore-color: #111;
+    --form-border-color: #ddd;
+    --input-back-color: #f8f8f8;
+    --input-fore-color: #111;
+    --input-border-color: #ddd;
+    --input-focus-color: #0288d1;
+    --input-invalid-color: #d32f2f;
+    --button-back-color: #e2e2e2;
+    --button-hover-back-color: #dcdcdc;
+    --button-fore-color: #212121;
+    --button-border-color: rgba(0, 0, 0, 0);
+    --button-hover-border-color: rgba(0, 0, 0, 0);
+    --button-group-border-color: rgba(124, 124, 124, 0.54)
+}
+
+form {
+    background: var(--form-back-color);
+    color: var(--form-fore-color);
+    border: .0625rem solid var(--form-border-color);
+    border-radius: var(--universal-border-radius);
+    margin: var(--universal-margin);
+    padding: calc(2 * var(--universal-padding)) var(--universal-padding)
+}
+
+fieldset {
+    border: .0625rem solid var(--form-border-color);
+    border-radius: var(--universal-border-radius);
+    margin: calc(var(--universal-margin) / 4);
+    padding: var(--universal-padding)
+}
+
+legend {
+    box-sizing: border-box;
+    display: table;
+    max-width: 100%;
+    white-space: normal;
+    font-weight: 700;
+    padding: calc(var(--universal-padding) / 2)
+}
+
+label {
+    padding: calc(var(--universal-padding) / 2) var(--universal-padding)
+}
+
+.input-group {
+    display: inline-block
+}
+
+.input-group.fluid {
+    display: flex;
+    align-items: center;
+    justify-content: center
+}
+
+.input-group.fluid>input {
+    max-width: 100%;
+    flex-grow: 1;
+    flex-basis: 0px
+}
+
+@media screen and (max-width: 767px) {
+    .input-group.fluid {
+        align-items: stretch;
+        flex-direction: column
+    }
+}
+
+.input-group.vertical {
+    display: flex;
+    align-items: stretch;
+    flex-direction: column
+}
+
+.input-group.vertical>input {
+    max-width: 100%;
+    flex-grow: 1;
+    flex-basis: 0px
+}
+
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+    height: auto
+}
+
+[type="search"] {
+    -webkit-appearance: textfield;
+    outline-offset: -2px
+}
+
+[type="search"]::-webkit-search-cancel-button,
+[type="search"]::-webkit-search-decoration {
+    -webkit-appearance: none
+}
+
+input:not([type]),
+[type="text"],
+[type="email"],
+[type="number"],
+[type="search"],
+[type="password"],
+[type="url"],
+[type="tel"],
+[type="checkbox"],
+[type="radio"],
+textarea,
+select {
+    box-sizing: border-box;
+    background: var(--input-back-color);
+    color: var(--input-fore-color);
+    border: .0625rem solid var(--input-border-color);
+    border-radius: var(--universal-border-radius);
+    margin: calc(var(--universal-margin) / 2);
+    padding: var(--universal-padding) calc(1.5 * var(--universal-padding))
+}
+
+input:not([type="button"]):not([type="submit"]):not([type="reset"]):hover,
+input:not([type="button"]):not([type="submit"]):not([type="reset"]):focus,
+textarea:hover,
+textarea:focus,
+select:hover,
+select:focus {
+    border-color: var(--input-focus-color);
+    box-shadow: none
+}
+
+input:not([type="button"]):not([type="submit"]):not([type="reset"]):invalid,
+input:not([type="button"]):not([type="submit"]):not([type="reset"]):focus:invalid,
+textarea:invalid,
+textarea:focus:invalid,
+select:invalid,
+select:focus:invalid {
+    border-color: var(--input-invalid-color);
+    box-shadow: none
+}
+
+input:not([type="button"]):not([type="submit"]):not([type="reset"])[readonly],
+textarea[readonly],
+select[readonly] {
+    background: var(--secondary-back-color)
+}
+
+select {
+    max-width: 100%
+}
+
+option {
+    overflow: hidden;
+    text-overflow: ellipsis
+}
+
+[type="checkbox"],
+[type="radio"] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    position: relative;
+    height: calc(1rem + var(--universal-padding) / 2);
+    width: calc(1rem + var(--universal-padding) / 2);
+    vertical-align: text-bottom;
+    padding: 0;
+    flex-basis: calc(1rem + var(--universal-padding) / 2) !important;
+    flex-grow: 0 !important
+}
+
+[type="checkbox"]:checked:before,
+[type="radio"]:checked:before {
+    position: absolute
+}
+
+[type="checkbox"]:checked:before {
+    content: '\2713';
+    font-family: sans-serif;
+    font-size: calc(1rem + var(--universal-padding) / 2);
+    top: calc(0rem - var(--universal-padding));
+    left: calc(var(--universal-padding) / 4)
+}
+
+[type="radio"] {
+    border-radius: 100%
+}
+
+[type="radio"]:checked:before {
+    border-radius: 100%;
+    content: '';
+    top: calc(.0625rem + var(--universal-padding) / 2);
+    left: calc(.0625rem + var(--universal-padding) / 2);
+    background: var(--input-fore-color);
+    width: 0.5rem;
+    height: 0.5rem
+}
+
+:placeholder-shown {
+    color: var(--input-fore-color)
+}
+
+::-ms-placeholder {
+    color: var(--input-fore-color);
+    opacity: 0.54
+}
+
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+    border-style: none;
+    padding: 0
+}
+
+button,
+html [type="button"],
+[type="reset"],
+[type="submit"] {
+    -webkit-appearance: button
+}
+
+button {
+    overflow: visible;
+    text-transform: none
+}
+
+button,
+[type="button"],
+[type="submit"],
+[type="reset"],
+a.button,
+label.button,
+.button,
+a[role="button"],
+label[role="button"],
+[role="button"] {
+    display: inline-block;
+    background: var(--button-back-color);
+    color: var(--button-fore-color);
+    border: .0625rem solid var(--button-border-color);
+    border-radius: var(--universal-border-radius);
+    padding: var(--universal-padding) calc(1.5 * var(--universal-padding));
+    margin: var(--universal-margin);
+    text-decoration: none;
+    cursor: pointer;
+    transition: background 0.3s
+}
+
+button:hover,
+button:focus,
+[type="button"]:hover,
+[type="button"]:focus,
+[type="submit"]:hover,
+[type="submit"]:focus,
+[type="reset"]:hover,
+[type="reset"]:focus,
+a.button:hover,
+a.button:focus,
+label.button:hover,
+label.button:focus,
+.button:hover,
+.button:focus,
+a[role="button"]:hover,
+a[role="button"]:focus,
+label[role="button"]:hover,
+label[role="button"]:focus,
+[role="button"]:hover,
+[role="button"]:focus {
+    background: var(--button-hover-back-color);
+    border-color: var(--button-hover-border-color)
+}
+
+input:disabled,
+input[disabled],
+textarea:disabled,
+textarea[disabled],
+select:disabled,
+select[disabled],
+button:disabled,
+button[disabled],
+.button:disabled,
+.button[disabled],
+[role="button"]:disabled,
+[role="button"][disabled] {
+    cursor: not-allowed;
+    opacity: .75
+}
+
+.button-group {
+    display: flex;
+    border: .0625rem solid var(--button-group-border-color);
+    border-radius: var(--universal-border-radius);
+    margin: var(--universal-margin)
+}
+
+.button-group>button,
+.button-group [type="button"],
+.button-group>[type="submit"],
+.button-group>[type="reset"],
+.button-group>.button,
+.button-group>[role="button"] {
+    margin: 0;
+    max-width: 100%;
+    flex: 1 1 auto;
+    text-align: center;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none
+}
+
+.button-group>:not(:first-child) {
+    border-left: .0625rem solid var(--button-group-border-color)
+}
+
+@media screen and (max-width: 767px) {
+    .button-group {
+        flex-direction: column
+    }
+
+    .button-group>:not(:first-child) {
+        border: 0;
+        border-top: .0625rem solid var(--button-group-border-color)
+    }
+}
+
+button.primary,
+[type="button"].primary,
+[type="submit"].primary,
+[type="reset"].primary,
+.button.primary,
+[role="button"].primary {
+    --button-back-color: #1976d2;
+    --button-fore-color: #f8f8f8
+}
+
+button.primary:hover,
+button.primary:focus,
+[type="button"].primary:hover,
+[type="button"].primary:focus,
+[type="submit"].primary:hover,
+[type="submit"].primary:focus,
+[type="reset"].primary:hover,
+[type="reset"].primary:focus,
+.button.primary:hover,
+.button.primary:focus,
+[role="button"].primary:hover,
+[role="button"].primary:focus {
+    --button-hover-back-color: #1565c0
+}
+
+button.secondary,
+[type="button"].secondary,
+[type="submit"].secondary,
+[type="reset"].secondary,
+.button.secondary,
+[role="button"].secondary {
+    --button-back-color: #d32f2f;
+    --button-fore-color: #f8f8f8
+}
+
+button.secondary:hover,
+button.secondary:focus,
+[type="button"].secondary:hover,
+[type="button"].secondary:focus,
+[type="submit"].secondary:hover,
+[type="submit"].secondary:focus,
+[type="reset"].secondary:hover,
+[type="reset"].secondary:focus,
+.button.secondary:hover,
+.button.secondary:focus,
+[role="button"].secondary:hover,
+[role="button"].secondary:focus {
+    --button-hover-back-color: #c62828
+}
+
+button.tertiary,
+[type="button"].tertiary,
+[type="submit"].tertiary,
+[type="reset"].tertiary,
+.button.tertiary,
+[role="button"].tertiary {
+    --button-back-color: #308732;
+    --button-fore-color: #f8f8f8
+}
+
+button.tertiary:hover,
+button.tertiary:focus,
+[type="button"].tertiary:hover,
+[type="button"].tertiary:focus,
+[type="submit"].tertiary:hover,
+[type="submit"].tertiary:focus,
+[type="reset"].tertiary:hover,
+[type="reset"].tertiary:focus,
+.button.tertiary:hover,
+.button.tertiary:focus,
+[role="button"].tertiary:hover,
+[role="button"].tertiary:focus {
+    --button-hover-back-color: #277529
+}
+
+button.inverse,
+[type="button"].inverse,
+[type="submit"].inverse,
+[type="reset"].inverse,
+.button.inverse,
+[role="button"].inverse {
+    --button-back-color: #212121;
+    --button-fore-color: #f8f8f8
+}
+
+button.inverse:hover,
+button.inverse:focus,
+[type="button"].inverse:hover,
+[type="button"].inverse:focus,
+[type="submit"].inverse:hover,
+[type="submit"].inverse:focus,
+[type="reset"].inverse:hover,
+[type="reset"].inverse:focus,
+.button.inverse:hover,
+.button.inverse:focus,
+[role="button"].inverse:hover,
+[role="button"].inverse:focus {
+    --button-hover-back-color: #111
+}
+
+button.small,
+[type="button"].small,
+[type="submit"].small,
+[type="reset"].small,
+.button.small,
+[role="button"].small {
+    padding: calc(0.5 * var(--universal-padding)) calc(0.75 * var(--universal-padding));
+    margin: var(--universal-margin)
+}
+
+button.large,
+[type="button"].large,
+[type="submit"].large,
+[type="reset"].large,
+.button.large,
+[role="button"].large {
+    padding: calc(1.5 * var(--universal-padding)) calc(2 * var(--universal-padding));
+    margin: var(--universal-margin)
+}
+
+:root {
+    --header-back-color: #f8f8f8;
+    --header-hover-back-color: #f0f0f0;
+    --header-fore-color: #444;
+    --header-border-color: #ddd;
+    --nav-back-color: #f8f8f8;
+    --nav-hover-back-color: #f0f0f0;
+    --nav-fore-color: #444;
+    --nav-border-color: #ddd;
+    --nav-link-color: #0277bd;
+    --footer-fore-color: #444;
+    --footer-back-color: #f8f8f8;
+    --footer-border-color: #ddd;
+    --footer-link-color: #0277bd;
+    --drawer-back-color: #f8f8f8;
+    --drawer-hover-back-color: #f0f0f0;
+    --drawer-border-color: #ddd;
+    --drawer-close-color: #444
+}
+
+header {
+    height: 3.1875rem;
+    background: var(--header-back-color);
+    color: var(--header-fore-color);
+    border-bottom: .0625rem solid var(--header-border-color);
+    padding: calc(var(--universal-padding) / 4) 0;
+    white-space: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden
+}
+
+header.row {
+    box-sizing: content-box
+}
+
+header .logo {
+    color: var(--header-fore-color);
+    font-size: 1.75rem;
+    padding: var(--universal-padding) calc(2 * var(--universal-padding));
+    text-decoration: none
+}
+
+header button,
+header [type="button"],
+header .button,
+header [role="button"] {
+    box-sizing: border-box;
+    position: relative;
+    top: calc(0rem - var(--universal-padding) / 4);
+    height: calc(3.1875rem + var(--universal-padding) / 2);
+    background: var(--header-back-color);
+    line-height: calc(3.1875rem - var(--universal-padding) * 1.5);
+    text-align: center;
+    color: var(--header-fore-color);
+    border: 0;
+    border-radius: 0;
+    margin: 0;
+    text-transform: uppercase
+}
+
+header button:hover,
+header button:focus,
+header [type="button"]:hover,
+header [type="button"]:focus,
+header .button:hover,
+header .button:focus,
+header [role="button"]:hover,
+header [role="button"]:focus {
+    background: var(--header-hover-back-color)
+}
+
+nav {
+    background: var(--nav-back-color);
+    color: var(--nav-fore-color);
+    border: .0625rem solid var(--nav-border-color);
+    border-radius: var(--universal-border-radius);
+    margin: var(--universal-margin)
+}
+
+nav * {
+    padding: var(--universal-padding) calc(1.5 * var(--universal-padding))
+}
+
+nav a,
+nav a:visited {
+    display: block;
+    color: var(--nav-link-color);
+    border-radius: var(--universal-border-radius);
+    transition: background 0.3s
+}
+
+nav a:hover,
+nav a:focus,
+nav a:visited:hover,
+nav a:visited:focus {
+    text-decoration: none;
+    background: var(--nav-hover-back-color)
+}
+
+nav .sublink-1 {
+    position: relative;
+    margin-left: calc(2 * var(--universal-padding))
+}
+
+nav .sublink-1:before {
+    position: absolute;
+    left: calc(var(--universal-padding) - 1 * var(--universal-padding));
+    top: -.0625rem;
+    content: '';
+    height: 100%;
+    border: .0625rem solid var(--nav-border-color);
+    border-left: 0
+}
+
+nav .sublink-2 {
+    position: relative;
+    margin-left: calc(4 * var(--universal-padding))
+}
+
+nav .sublink-2:before {
+    position: absolute;
+    left: calc(var(--universal-padding) - 3 * var(--universal-padding));
+    top: -.0625rem;
+    content: '';
+    height: 100%;
+    border: .0625rem solid var(--nav-border-color);
+    border-left: 0
+}
+
+footer {
+    background: var(--footer-back-color);
+    color: var(--footer-fore-color);
+    border-top: .0625rem solid var(--footer-border-color);
+    padding: calc(2 * var(--universal-padding)) var(--universal-padding);
+    font-size: .875rem
+}
+
+footer a,
+footer a:visited {
+    color: var(--footer-link-color)
+}
+
+header.sticky {
+    position: -webkit-sticky;
+    position: sticky;
+    z-index: 1101;
+    top: 0
+}
+
+footer.sticky {
+    position: -webkit-sticky;
+    position: sticky;
+    z-index: 1101;
+    bottom: 0
+}
+
+.drawer-toggle:before {
+    display: inline-block;
+    position: relative;
+    vertical-align: bottom;
+    content: '\00a0\2261\00a0';
+    font-family: sans-serif;
+    font-size: 1.5em
+}
+
+@media screen and (min-width: 768px) {
+    .drawer-toggle:not(.persistent) {
+        display: none
+    }
+}
+
+[type="checkbox"].drawer {
+    height: 1px;
+    width: 1px;
+    margin: -1px;
+    overflow: hidden;
+    position: absolute;
+    clip: rect(0 0 0 0);
+    -webkit-clip-path: inset(100%);
+    clip-path: inset(100%)
+}
+
+[type="checkbox"].drawer+* {
+    display: block;
+    box-sizing: border-box;
+    position: fixed;
+    top: 0;
+    width: 320px;
+    height: 100vh;
+    overflow-y: auto;
+    background: var(--drawer-back-color);
+    border: .0625rem solid var(--drawer-border-color);
+    border-radius: 0;
+    margin: 0;
+    z-index: 1110;
+    right: -320px;
+    transition: right 0.3s
+}
+
+[type="checkbox"].drawer+* .drawer-close {
+    position: absolute;
+    top: var(--universal-margin);
+    right: var(--universal-margin);
+    z-index: 1111;
+    width: 2rem;
+    height: 2rem;
+    border-radius: var(--universal-border-radius);
+    padding: var(--universal-padding);
+    margin: 0;
+    cursor: pointer;
+    transition: background 0.3s
+}
+
+[type="checkbox"].drawer+* .drawer-close:before {
+    display: block;
+    content: '\00D7';
+    color: var(--drawer-close-color);
+    position: relative;
+    font-family: sans-serif;
+    font-size: 2rem;
+    line-height: 1;
+    text-align: center
+}
+
+[type="checkbox"].drawer+* .drawer-close:hover,
+[type="checkbox"].drawer+* .drawer-close:focus {
+    background: var(--drawer-hover-back-color)
+}
+
+@media screen and (max-width: 320px) {
+    [type="checkbox"].drawer+* {
+        width: 100%
+    }
+}
+
+[type="checkbox"].drawer:checked+* {
+    right: 0
+}
+
+@media screen and (min-width: 768px) {
+    [type="checkbox"].drawer:not(.persistent)+* {
+        position: static;
+        height: 100%;
+        z-index: 1100
+    }
+
+    [type="checkbox"].drawer:not(.persistent)+* .drawer-close {
+        display: none
+    }
+}
+
+:root {
+    --table-border-color: #aaa;
+    --table-border-separator-color: #666;
+    --table-head-back-color: #e6e6e6;
+    --table-head-fore-color: #111;
+    --table-body-back-color: #f8f8f8;
+    --table-body-fore-color: #111;
+    --table-body-alt-back-color: #eee
+}
+
+table {
+    border-collapse: separate;
+    border-spacing: 0;
+    margin: 0;
+    display: flex;
+    flex: 0 1 auto;
+    flex-flow: row wrap;
+    padding: var(--universal-padding);
+    padding-top: 0
+}
+
+table caption {
+    font-size: 1.5rem;
+    margin: calc(2 * var(--universal-margin)) 0;
+    max-width: 100%;
+    flex: 0 0 100%
+}
+
+table thead,
+table tbody {
+    display: flex;
+    flex-flow: row wrap;
+    border: .0625rem solid var(--table-border-color)
+}
+
+table thead {
+    z-index: 999;
+    border-radius: var(--universal-border-radius) var(--universal-border-radius) 0 0;
+    border-bottom: .0625rem solid var(--table-border-separator-color)
+}
+
+table tbody {
+    border-top: 0;
+    margin-top: calc(0 - var(--universal-margin));
+    border-radius: 0 0 var(--universal-border-radius) var(--universal-border-radius)
+}
+
+table tr {
+    display: flex;
+    padding: 0
+}
+
+table th,
+table td {
+    padding: calc(2 * var(--universal-padding))
+}
+
+table th {
+    text-align: left;
+    background: var(--table-head-back-color);
+    color: var(--table-head-fore-color)
+}
+
+table td {
+    background: var(--table-body-back-color);
+    color: var(--table-body-fore-color);
+    border-top: .0625rem solid var(--table-border-color)
+}
+
+table:not(.horizontal) {
+    overflow: auto;
+    max-height: 400px
+}
+
+table:not(.horizontal) thead,
+table:not(.horizontal) tbody {
+    max-width: 100%;
+    flex: 0 0 100%
+}
+
+table:not(.horizontal) tr {
+    flex-flow: row wrap;
+    flex: 0 0 100%
+}
+
+table:not(.horizontal) th,
+table:not(.horizontal) td {
+    flex: 1 0 0%;
+    overflow: hidden;
+    text-overflow: ellipsis
+}
+
+table:not(.horizontal) thead {
+    position: sticky;
+    top: 0
+}
+
+table:not(.horizontal) tbody tr:first-child td {
+    border-top: 0
+}
+
+table.horizontal {
+    border: 0
+}
+
+table.horizontal thead,
+table.horizontal tbody {
+    border: 0;
+    flex: .2 0 0;
+    flex-flow: row nowrap
+}
+
+table.horizontal tbody {
+    overflow: auto;
+    justify-content: space-between;
+    flex: .8 0 0;
+    margin-left: 0;
+    padding-bottom: calc(var(--universal-padding) / 4)
+}
+
+table.horizontal tr {
+    flex-direction: column;
+    flex: 1 0 auto
+}
+
+table.horizontal th,
+table.horizontal td {
+    width: auto;
+    border: 0;
+    border-bottom: .0625rem solid var(--table-border-color)
+}
+
+table.horizontal th:not(:first-child),
+table.horizontal td:not(:first-child) {
+    border-top: 0
+}
+
+table.horizontal th {
+    text-align: right;
+    border-left: .0625rem solid var(--table-border-color);
+    border-right: .0625rem solid var(--table-border-separator-color)
+}
+
+table.horizontal thead tr:first-child {
+    padding-left: 0
+}
+
+table.horizontal th:first-child,
+table.horizontal td:first-child {
+    border-top: .0625rem solid var(--table-border-color)
+}
+
+table.horizontal tbody tr:last-child td {
+    border-right: .0625rem solid var(--table-border-color)
+}
+
+table.horizontal tbody tr:last-child td:first-child {
+    border-top-right-radius: 0.25rem
+}
+
+table.horizontal tbody tr:last-child td:last-child {
+    border-bottom-right-radius: 0.25rem
+}
+
+table.horizontal thead tr:first-child th:first-child {
+    border-top-left-radius: 0.25rem
+}
+
+table.horizontal thead tr:first-child th:last-child {
+    border-bottom-left-radius: 0.25rem
+}
+
+@media screen and (max-width: 767px) {
+
+    table,
+    table.horizontal {
+        border-collapse: collapse;
+        border: 0;
+        width: 100%;
+        display: table
+    }
+
+    table thead,
+    table th,
+    table.horizontal thead,
+    table.horizontal th {
+        border: 0;
+        height: 1px;
+        width: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        clip: rect(0 0 0 0);
+        -webkit-clip-path: inset(100%);
+        clip-path: inset(100%)
+    }
+
+    table tbody,
+    table.horizontal tbody {
+        border: 0;
+        display: table-row-group
+    }
+
+    table tr,
+    table.horizontal tr {
+        display: block;
+        border: .0625rem solid var(--table-border-color);
+        border-radius: var(--universal-border-radius);
+        background: #fafafa;
+        padding: var(--universal-padding);
+        margin: var(--universal-margin);
+        margin-bottom: calc(2 * var(--universal-margin))
+    }
+
+    table th,
+    table td,
+    table.horizontal th,
+    table.horizontal td {
+        width: auto
+    }
+
+    table td,
+    table.horizontal td {
+        display: block;
+        border: 0;
+        text-align: right
+    }
+
+    table td:before,
+    table.horizontal td:before {
+        content: attr(data-label);
+        float: left;
+        font-weight: 600
+    }
+
+    table th:first-child,
+    table td:first-child,
+    table.horizontal th:first-child,
+    table.horizontal td:first-child {
+        border-top: 0
+    }
+
+    table tbody tr:last-child td,
+    table.horizontal tbody tr:last-child td {
+        border-right: 0
+    }
+}
+
+:root {
+    --table-body-alt-back-color: #eee
+}
+
+table.striped tr:nth-of-type(2n)>td {
+    background: var(--table-body-alt-back-color)
+}
+
+@media screen and (max-width: 768px) {
+    table.striped tr:nth-of-type(2n) {
+        background: var(--table-body-alt-back-color)
+    }
+}
+
+:root {
+    --table-body-hover-back-color: #90caf9
+}
+
+table.hoverable tr:hover,
+table.hoverable tr:hover>td,
+table.hoverable tr:focus,
+table.hoverable tr:focus>td {
+    background: var(--table-body-hover-back-color)
+}
+
+@media screen and (max-width: 768px) {
+
+    table.hoverable tr:hover,
+    table.hoverable tr:hover>td,
+    table.hoverable tr:focus,
+    table.hoverable tr:focus>td {
+        background: var(--table-body-hover-back-color)
+    }
+}
+
+:root {
+    --mark-back-color: #0277bd;
+    --mark-fore-color: #fafafa
+}
+
+mark {
+    background: var(--mark-back-color);
+    color: var(--mark-fore-color);
+    font-size: .95em;
+    line-height: 1em;
+    border-radius: var(--universal-border-radius);
+    padding: calc(var(--universal-padding) / 4) calc(var(--universal-padding) / 2)
+}
+
+mark.inline-block {
+    display: inline-block;
+    font-size: 1em;
+    line-height: 1.5;
+    padding: calc(var(--universal-padding) / 2) var(--universal-padding)
+}
+
+:root {
+    --toast-back-color: #424242;
+    --toast-fore-color: #fafafa
+}
+
+.toast {
+    position: fixed;
+    bottom: calc(var(--universal-margin) * 3);
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1111;
+    color: var(--toast-fore-color);
+    background: var(--toast-back-color);
+    border-radius: calc(var(--universal-border-radius) * 16);
+    padding: var(--universal-padding) calc(var(--universal-padding) * 3)
+}
+
+:root {
+    --tooltip-back-color: #212121;
+    --tooltip-fore-color: #fafafa
+}
+
+.tooltip {
+    position: relative;
+    display: inline-block
+}
+
+.tooltip:before,
+.tooltip:after {
+    position: absolute;
+    opacity: 0;
+    clip: rect(0 0 0 0);
+    -webkit-clip-path: inset(100%);
+    clip-path: inset(100%);
+    transition: all 0.3s;
+    z-index: 1010;
+    left: 50%
+}
+
+.tooltip:not(.bottom):before,
+.tooltip:not(.bottom):after {
+    bottom: 75%
+}
+
+.tooltip.bottom:before,
+.tooltip.bottom:after {
+    top: 75%
+}
+
+.tooltip:hover:before,
+.tooltip:hover:after,
+.tooltip:focus:before,
+.tooltip:focus:after {
+    opacity: 1;
+    clip: auto;
+    -webkit-clip-path: inset(0%);
+    clip-path: inset(0%)
+}
+
+.tooltip:before {
+    content: '';
+    background: transparent;
+    border: var(--universal-margin) solid transparent;
+    left: calc(50% - var(--universal-margin))
+}
+
+.tooltip:not(.bottom):before {
+    border-top-color: #212121
+}
+
+.tooltip.bottom:before {
+    border-bottom-color: #212121
+}
+
+.tooltip:after {
+    content: attr(aria-label);
+    color: var(--tooltip-fore-color);
+    background: var(--tooltip-back-color);
+    border-radius: var(--universal-border-radius);
+    padding: var(--universal-padding);
+    white-space: nowrap;
+    transform: translateX(-50%)
+}
+
+.tooltip:not(.bottom):after {
+    margin-bottom: calc(2 * var(--universal-margin))
+}
+
+.tooltip.bottom:after {
+    margin-top: calc(2 * var(--universal-margin))
+}
+
+:root {
+    --modal-overlay-color: rgba(0, 0, 0, 0.45);
+    --modal-close-color: #444;
+    --modal-close-hover-color: #f0f0f0
+}
+
+[type="checkbox"].modal {
+    height: 1px;
+    width: 1px;
+    margin: -1px;
+    overflow: hidden;
+    position: absolute;
+    clip: rect(0 0 0 0);
+    -webkit-clip-path: inset(100%);
+    clip-path: inset(100%)
+}
+
+[type="checkbox"].modal+div {
+    position: fixed;
+    top: 0;
+    left: 0;
+    display: none;
+    width: 100vw;
+    height: 100vh;
+    background: var(--modal-overlay-color)
+}
+
+[type="checkbox"].modal+div .card {
+    margin: 0 auto;
+    max-height: 50vh;
+    overflow: auto
+}
+
+[type="checkbox"].modal+div .card .modal-close {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: var(--universal-border-radius);
+    padding: var(--universal-padding);
+    margin: 0;
+    cursor: pointer;
+    transition: background 0.3s
+}
+
+[type="checkbox"].modal+div .card .modal-close:before {
+    display: block;
+    content: '\00D7';
+    color: var(--modal-close-color);
+    position: relative;
+    font-family: sans-serif;
+    font-size: 1.75rem;
+    line-height: 1;
+    text-align: center
+}
+
+[type="checkbox"].modal+div .card .modal-close:hover,
+[type="checkbox"].modal+div .card .modal-close:focus {
+    background: var(--modal-close-hover-color)
+}
+
+[type="checkbox"].modal:checked+div {
+    display: flex;
+    flex: 0 1 auto;
+    z-index: 1200
+}
+
+[type="checkbox"].modal:checked+div .card .modal-close {
+    z-index: 1211
+}
+
+:root {
+    --collapse-label-back-color: #e8e8e8;
+    --collapse-label-fore-color: #212121;
+    --collapse-label-hover-back-color: #f0f0f0;
+    --collapse-selected-label-back-color: #ececec;
+    --collapse-border-color: #ddd;
+    --collapse-content-back-color: #fafafa;
+    --collapse-selected-label-border-color: #0277bd
+}
+
+.collapse {
+    width: calc(100% - 2 * var(--universal-margin));
+    opacity: 1;
+    display: flex;
+    flex-direction: column;
+    margin: var(--universal-margin);
+    border-radius: var(--universal-border-radius)
+}
+
+.collapse>[type="radio"],
+.collapse>[type="checkbox"] {
+    height: 1px;
+    width: 1px;
+    margin: -1px;
+    overflow: hidden;
+    position: absolute;
+    clip: rect(0 0 0 0);
+    -webkit-clip-path: inset(100%);
+    clip-path: inset(100%)
+}
+
+.collapse>label {
+    flex-grow: 1;
+    display: inline-block;
+    height: 1.5rem;
+    cursor: pointer;
+    transition: background 0.3s;
+    color: var(--collapse-label-fore-color);
+    background: var(--collapse-label-back-color);
+    border: .0625rem solid var(--collapse-border-color);
+    padding: calc(1.5 * var(--universal-padding))
+}
+
+.collapse>label:hover,
+.collapse>label:focus {
+    background: var(--collapse-label-hover-back-color)
+}
+
+.collapse>label+div {
+    flex-basis: auto;
+    height: 1px;
+    width: 1px;
+    margin: -1px;
+    overflow: hidden;
+    position: absolute;
+    clip: rect(0 0 0 0);
+    -webkit-clip-path: inset(100%);
+    clip-path: inset(100%);
+    transition: max-height 0.3s;
+    max-height: 1px
+}
+
+.collapse>:checked+label {
+    background: var(--collapse-selected-label-back-color);
+    border-bottom-color: var(--collapse-selected-label-border-color)
+}
+
+.collapse>:checked+label+div {
+    box-sizing: border-box;
+    position: relative;
+    width: 100%;
+    height: auto;
+    overflow: auto;
+    margin: 0;
+    background: var(--collapse-content-back-color);
+    border: .0625rem solid var(--collapse-border-color);
+    border-top: 0;
+    padding: var(--universal-padding);
+    clip: auto;
+    -webkit-clip-path: inset(0%);
+    clip-path: inset(0%);
+    max-height: 400px
+}
+
+.collapse>label:not(:first-of-type) {
+    border-top: 0
+}
+
+.collapse>label:first-of-type {
+    border-radius: var(--universal-border-radius) var(--universal-border-radius) 0 0
+}
+
+.collapse>label:last-of-type:not(:first-of-type) {
+    border-radius: 0 0 var(--universal-border-radius) var(--universal-border-radius)
+}
+
+.collapse>label:last-of-type:first-of-type {
+    border-radius: var(--universal-border-radius)
+}
+
+.collapse>:checked:last-of-type:not(:first-of-type)+label {
+    border-radius: 0
+}
+
+.collapse>:checked:last-of-type+label+div {
+    border-radius: 0 0 var(--universal-border-radius) var(--universal-border-radius)
+}
+
+mark.secondary {
+    --mark-back-color: #d32f2f
+}
+
+mark.tertiary {
+    --mark-back-color: #308732
+}
+
+mark.tag {
+    padding: calc(var(--universal-padding)/2) var(--universal-padding);
+    border-radius: 1em
+}
+
+:root {
+    --progress-back-color: #ddd;
+    --progress-fore-color: #555
+}
+
+progress {
+    display: block;
+    vertical-align: baseline;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    height: .75rem;
+    width: calc(100% - 2 * var(--universal-margin));
+    margin: var(--universal-margin);
+    border: 0;
+    border-radius: calc(2 * var(--universal-border-radius));
+    background: var(--progress-back-color);
+    color: var(--progress-fore-color)
+}
+
+progress::-webkit-progress-value {
+    background: var(--progress-fore-color);
+    border-top-left-radius: calc(2 * var(--universal-border-radius));
+    border-bottom-left-radius: calc(2 * var(--universal-border-radius))
+}
+
+progress::-webkit-progress-bar {
+    background: var(--progress-back-color)
+}
+
+progress::-moz-progress-bar {
+    background: var(--progress-fore-color);
+    border-top-left-radius: calc(2 * var(--universal-border-radius));
+    border-bottom-left-radius: calc(2 * var(--universal-border-radius))
+}
+
+progress[value="1000"]::-webkit-progress-value {
+    border-radius: calc(2 * var(--universal-border-radius))
+}
+
+progress[value="1000"]::-moz-progress-bar {
+    border-radius: calc(2 * var(--universal-border-radius))
+}
+
+progress.inline {
+    display: inline-block;
+    vertical-align: middle;
+    width: 60%
+}
+
+:root {
+    --spinner-back-color: #ddd;
+    --spinner-fore-color: #555
+}
+
+@keyframes spinner-donut-anim {
+    0% {
+        transform: rotate(0deg)
+    }
+
+    100% {
+        transform: rotate(360deg)
+    }
+}
+
+.spinner {
+    display: inline-block;
+    margin: var(--universal-margin);
+    border: .25rem solid var(--spinner-back-color);
+    border-left: .25rem solid var(--spinner-fore-color);
+    border-radius: 50%;
+    width: 1.25rem;
+    height: 1.25rem;
+    animation: spinner-donut-anim 1.2s linear infinite
+}
+
+progress.primary {
+    --progress-fore-color: #1976d2
+}
+
+progress.secondary {
+    --progress-fore-color: #d32f2f
+}
+
+progress.tertiary {
+    --progress-fore-color: #308732
+}
+
+.spinner.primary {
+    --spinner-fore-color: #1976d2
+}
+
+.spinner.secondary {
+    --spinner-fore-color: #d32f2f
+}
+
+.spinner.tertiary {
+    --spinner-fore-color: #308732
+}
+
+span[class^='icon-'] {
+    display: inline-block;
+    height: 1em;
+    width: 1em;
+    vertical-align: -0.125em;
+    background-size: contain;
+    margin: 0 calc(var(--universal-margin) / 4)
+}
+
+span[class^='icon-'].secondary {
+    -webkit-filter: invert(25%);
+    filter: invert(25%)
+}
+
+span[class^='icon-'].inverse {
+    -webkit-filter: invert(100%);
+    filter: invert(100%)
+}
+
+:root {
+    --generic-border-color: rgba(0, 0, 0, 0.3);
+    --generic-box-shadow: 0 .25rem .25rem 0 rgba(0, 0, 0, 0.125), 0 .125rem .125rem -.125rem rgba(0, 0, 0, 0.25)
+}
+
+.hidden {
+    display: none !important
+}
+
+.visually-hidden {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    margin: -1px !important;
+    border: 0 !important;
+    padding: 0 !important;
+    clip: rect(0 0 0 0) !important;
+    -webkit-clip-path: inset(100%) !important;
+    clip-path: inset(100%) !important;
+    overflow: hidden !important
+}
+
+.bordered {
+    border: .0625rem solid var(--generic-border-color) !important
+}
+
+.rounded {
+    border-radius: var(--universal-border-radius) !important
+}
+
+.circular {
+    border-radius: 50% !important
+}
+
+.shadowed {
+    box-shadow: var(--generic-box-shadow) !important
+}
+
+.responsive-margin {
+    margin: calc(var(--universal-margin) / 4) !important
+}
+
+@media screen and (min-width: 768px) {
+    .responsive-margin {
+        margin: calc(var(--universal-margin) / 2) !important
+    }
+}
+
+@media screen and (min-width: 1280px) {
+    .responsive-margin {
+        margin: var(--universal-margin) !important
+    }
+}
+
+.responsive-padding {
+    padding: calc(var(--universal-padding) / 4) !important
+}
+
+@media screen and (min-width: 768px) {
+    .responsive-padding {
+        padding: calc(var(--universal-padding) / 2) !important
+    }
+}
+
+@media screen and (min-width: 1280px) {
+    .responsive-padding {
+        padding: var(--universal-padding) !important
+    }
+}
+
+@media screen and (max-width: 767px) {
+    .hidden-sm {
+        display: none !important
+    }
+}
+
+@media screen and (min-width: 768px) and (max-width: 1279px) {
+    .hidden-md {
+        display: none !important
+    }
+}
+
+@media screen and (min-width: 1280px) {
+    .hidden-lg {
+        display: none !important
+    }
+}
+
+@media screen and (max-width: 767px) {
+    .visually-hidden-sm {
+        position: absolute !important;
+        width: 1px !important;
+        height: 1px !important;
+        margin: -1px !important;
+        border: 0 !important;
+        padding: 0 !important;
+        clip: rect(0 0 0 0) !important;
+        -webkit-clip-path: inset(100%) !important;
+        clip-path: inset(100%) !important;
+        overflow: hidden !important
+    }
+}
+
+@media screen and (min-width: 768px) and (max-width: 1279px) {
+    .visually-hidden-md {
+        position: absolute !important;
+        width: 1px !important;
+        height: 1px !important;
+        margin: -1px !important;
+        border: 0 !important;
+        padding: 0 !important;
+        clip: rect(0 0 0 0) !important;
+        -webkit-clip-path: inset(100%) !important;
+        clip-path: inset(100%) !important;
+        overflow: hidden !important
+    }
+}
+
+@media screen and (min-width: 1280px) {
+    .visually-hidden-lg {
+        position: absolute !important;
+        width: 1px !important;
+        height: 1px !important;
+        margin: -1px !important;
+        border: 0 !important;
+        padding: 0 !important;
+        clip: rect(0 0 0 0) !important;
+        -webkit-clip-path: inset(100%) !important;
+        clip-path: inset(100%) !important;
+        overflow: hidden !important
+    }
+}

--- a/docs/style.css
+++ b/docs/style.css
@@ -891,6 +891,7 @@ label {
 }
 
 [type="search"] {
+    appearance: textfield;
     -webkit-appearance: textfield;
     outline-offset: -2px
 }
@@ -1018,6 +1019,7 @@ button,
 html [type="button"],
 [type="reset"],
 [type="submit"] {
+    appearance: button;
     -webkit-appearance: button
 }
 
@@ -2093,7 +2095,6 @@ mark.tag {
 
 progress {
     display: block;
-    vertical-align: baseline;
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;

--- a/docs/tips.html
+++ b/docs/tips.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mini.css/3.0.1/mini-default.min.css"> -->
+<link rel="stylesheet" href="style.css">
 <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>

--- a/docs/tips.html
+++ b/docs/tips.html
@@ -1,6 +1,8 @@
+<!DOCTYPE html>
 <html>
 <head>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mini.css/3.0.1/mini-default.min.css">
+<!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mini.css/3.0.1/mini-default.min.css"> -->
+<link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
@@ -8,31 +10,32 @@
 <h1>LADXR: Tips</h1>
 
 <h3>Locations</h3>
-<p>All chests and dungeon keys are always randomized. Also, the 3 songs (Marin, Mambo and Manu) give a you an item if you present them the Ocarina. The seashell mansion 20 shells reward is also shuffled, but the 5 and 10 shell reward is not, as those can be missed.</p>
-<p>The moblin cave with Bowwow contains a chest instead. The color dungeon gives 2 items at the end instead of a choice of tunic. Other item locations are: The toadstool, the reward for delivering the toadstool, hidden seashells, golden leaves, the Mad Batters (capacity upgrades), the shovel/bow in the shop, the rooster's grave, and all of the key locations.</p>
-<p>Also, often forgotten, the hookshop drop from master stalfos in D5 is also randomized.</p>
-<p>Finaly, new players often forget the following locations: The heart piece hidden in the water at the castle, the heart piece hidden in the bomb cave (screen before the honey). Bonk seashells (run with pegasus boots against the tree in at the Tail Cave, and the tree right of Mabe Village, next to the phone booth).</p>
-<p>If you still need help, you should look at <a href="https://magpietracker.us/">Magpie</a>, a tracker for this project.</p>
+<p>All chests and dungeon keys are always randomized. Also, the 3 songs (Marin, Mambo, and Manu) give a you an item if you present them the Ocarina. The seashell mansion 20 shells reward is also shuffled, but the 5 and 10 shell reward is not, as those can be missed.</p>
+<p>The moblin cave with Bowwow contains a chest instead. The color dungeon gives 2 items at the end instead of a choice of tunic. Other item locations are: The toadstool, the reward for delivering the toadstool, hidden seashells, heart pieces, heart containers, golden leaves, the Mad Batters (capacity upgrades), the shovel/bow in the shop, the rooster's grave, and all of the keys' (tail,slime,angler,face,bird) locations.</p>
+<p>Finally, new players often forget the following locations: the heart piece hidden in the water at the castle, the heart piece hidden in the bomb cave (screen before the honey), bonk seashells (run with pegasus boots against the tree in at the Tail Cave, and the tree right of Mabe Village, next to the phone booth), and the hookshop drop from Master Stalfos in D5.</p>
+<p>If you still need help, you should look at <a href="https://magpietracker.us/">Magpie</a>, a tracker for this project; and if you're still lost, catch us in the <a href="https://discord.gg/XTw7X2G">Discord server</a>.</p>
 
-<h3>Color dungeon</h3>
-<p>The color dungeon is part of the item shuffle, the red and blue tunics are shuffled in the item pool. Which means the fairy at the end of the color dungeon gives out two random items.</p>
-<p>To access the color dungeon, you need the power bracelet. And you need to push the gravestones in the right order. Which is "down, left, up, right, up", going from the lower right gravestone, to the one left of it, above it, and then to the right.</p>
+<h3>Color Dungeon</h3>
+<p>The Color Dungeon is part of the item shuffle, and the red/blue tunics are shuffled in the item pool. Which means the fairy at the end of the color dungeon gives out two random items.</p>
+<p>To access the color dungeon, you need the power bracelet, and you need to push the gravestones in the right order: "down, left, up, right, up", going from the lower right gravestone, to the one left of it, above it, and then to the right.</p>
 
 <h3>Bowwow</h3>
 <p>Bowwow is in a chest, somewhere. After you find him, he will always be in the swamp with you, but not anywhere else.</p>
 
 <h3>Added things</h3>
-<p>In your save and quit menu there is a 3th option to return to your home. This has two uses: it speeds up the game, and prevents softlocks.</p>
+<p>In your save and quit menu, there is a 3rd option to return to your home. This has two main uses: it speeds up the game, and prevents softlocks (common in entrance rando).</p>
 <p>If you have weapons that require ammunition (bombs, powder, arrows), a ghost will show up inside Marin's house. He will refill you up to 10 ammunition, so you do not run out.</p>
 <p>The flying rooster is (optionally) available as an item.</p>
-<p>You can access the Bird Key cave with the L2 Power Bracelet.</p>
+<p>You can access the Bird Key cave item with the L2 Power Bracelet.</p>
+<p>Boomerang cave is now a random item gift by default (available post-bombs), and boomerang is in the item pool.</p>
+<p>Your inventory has been increased by four, to accommodate these items now coexisting with eachother.</p>
 
 <h3>Removed things</h3>
 <p>The ghost mini-quest after D4 never shows up, his seashell reward is always available.</p>
-<p>The wallrus is moved a bit, so you can access the desert without taking Marin on a date.</p>
+<p>The walrus is moved a bit, so that you can access the desert without taking Marin on a date.</p>
 
 <h3>Logic</h3>
-<p>Stealing from the shop is never in logic. Depending on your settings you can only steal after you find the sword, always or never.</p>
+<p>Stealing from the shop is never in logic. Depending on your settings, you can only steal after you find the sword, always, or never.</p>
 <p>Do not forget that there are two items in the rafting ride. You can access this with just Hookshot or Flippers.</p>
 <p>Killing enemies with bombs is in normal logic. You can switch to casual logic if you do not want this.</p>
 <p>D7 confuses some people, but by dropping down pits on the 2nd floor you can access almost all of this dungeon, even without feather and power bracelet.</p>

--- a/docs/tips.html
+++ b/docs/tips.html
@@ -23,11 +23,12 @@
 <h3>Added things</h3>
 <p>In your save and quit menu there is a 3th option to return to your home. This has two uses, it speeds up the game as you can move around quicker. And it allows you to recover in case you lock yourself into a one way street. Which is more common with Entrance Randomization enabled.</p>
 <p>If you have weapons that require ammunition (bombs, powder, arrows), the ghost will show up inside Marins house. He will give you up to 10 ammonition, so you do not run out.</p>
+<p>The flying rooster is (optionally) available as an item.</p>
+<p>You can access the Bird Key cave with the L2 Power Bracelet.</p>
 
 <h3>Removed things</h3>
 <p>The ghost mini-quest after D4 never shows up, his seashell reward is always available.</p>
 <p>The wallrus is moved a bit, so you can access the desert without taking Marin on a date.</p>
-<p>The flying rooster isn't available. You can access the bird key location with the L2 Power Bracelet.</p>
 
 <h3>Logic</h3>
 <p>Stealing from the shop is never in logic. Depending on your settings you can only steal after you find the sword, always or never.</p>

--- a/docs/tips.html
+++ b/docs/tips.html
@@ -9,20 +9,21 @@
 
 <h3>Locations</h3>
 <p>All chests and dungeon keys are always randomized. Also, the 3 songs (Marin, Mambo and Manu) give a you an item if you present them the Ocarina. The seashell mansion 20 shells reward is also shuffled, but the 5 and 10 shell reward is not, as those can be missed.</p>
-<p>The moblin cave with Bowwow contains a chest instead. The color dungeon gives 2 items at the end instead of a choice of tunic. Other item locations are: The toadstool, the reward for delivering the toadstool, hidden seashells, golden leafs, the MadBatters (capacity upgrades) the shovel/bow in the shop. And the angler key and face key.</p>
+<p>The moblin cave with Bowwow contains a chest instead. The color dungeon gives 2 items at the end instead of a choice of tunic. Other item locations are: The toadstool, the reward for delivering the toadstool, hidden seashells, golden leaves, the Mad Batters (capacity upgrades), the shovel/bow in the shop, the rooster's grave, and all of the key locations.</p>
 <p>Also, often forgotten, the hookshop drop from master stalfos in D5 is also randomized.</p>
-<p>Finaly, new players often forget the following locations: The heart piece hidden in the water at the castle, the heart piece hidden in the bomb cave (screen before the honey). Bonk seashells (run with pegasus boots against the tree in at the Tail Cave, and the tree right of Mabe Village, next to the phone booth)</p>
+<p>Finaly, new players often forget the following locations: The heart piece hidden in the water at the castle, the heart piece hidden in the bomb cave (screen before the honey). Bonk seashells (run with pegasus boots against the tree in at the Tail Cave, and the tree right of Mabe Village, next to the phone booth).</p>
+<p>If you still need help, you should look at <a href="https://magpietracker.us/">Magpie</a>, a tracker for this project.</p>
 
 <h3>Color dungeon</h3>
 <p>The color dungeon is part of the item shuffle, the red and blue tunics are shuffled in the item pool. Which means the fairy at the end of the color dungeon gives out two random items.</p>
 <p>To access the color dungeon, you need the power bracelet. And you need to push the gravestones in the right order. Which is "down, left, up, right, up", going from the lower right gravestone, to the one left of it, above it, and then to the right.</p>
 
 <h3>Bowwow</h3>
-<p>Bowwow is in a chest, somewhere. After you find him he will always be in the swamp with you but not anywhere else.</p>
+<p>Bowwow is in a chest, somewhere. After you find him, he will always be in the swamp with you, but not anywhere else.</p>
 
 <h3>Added things</h3>
-<p>In your save and quit menu there is a 3th option to return to your home. This has two uses, it speeds up the game as you can move around quicker. And it allows you to recover in case you lock yourself into a one way street. Which is more common with Entrance Randomization enabled.</p>
-<p>If you have weapons that require ammunition (bombs, powder, arrows), the ghost will show up inside Marins house. He will give you up to 10 ammonition, so you do not run out.</p>
+<p>In your save and quit menu there is a 3th option to return to your home. This has two uses: it speeds up the game, and prevents softlocks.</p>
+<p>If you have weapons that require ammunition (bombs, powder, arrows), a ghost will show up inside Marin's house. He will refill you up to 10 ammunition, so you do not run out.</p>
 <p>The flying rooster is (optionally) available as an item.</p>
 <p>You can access the Bird Key cave with the L2 Power Bracelet.</p>
 
@@ -37,7 +38,7 @@
 <p>D7 confuses some people, but by dropping down pits on the 2nd floor you can access almost all of this dungeon, even without feather and power bracelet.</p>
 
 <h3>Tech</h3>
-<p>The toadstool and magic powder used to be the same type of item. LADXR turns this into two items that you can have a the same time. 4 extra item slots in your inventory where added to support this extra item and have the ability to own the boomerang.</p>
+<p>The toadstool and magic powder used to be the same type of item. LADXR turns this into two items that you can have a the same time. 4 extra item slots in your inventory were added to support this extra item, and have the ability to own the boomerang.</p>
 <p>The glitch where the slime key is effectively a 6th golden leaf is fixed, and golden leaves can be collected fine next to the slime key.</p>
 
 </body>


### PR DESCRIPTION
This updates the docs, mainly to just match current rando logic, and some typoes I spotted on the way. It also fixes icons, adds `<!DOCTYPE html>` to the top, and removes the dependency upon CloudFlare for css (by embedding it).