### PR TITLE
logic: bomb walls, d2 exit, and lanmola shorthand

### DIFF
--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -183,7 +183,8 @@ class World:
         Location().add(Seashell(0x0A8)).connect(prairie_plateau, SHOVEL)  # at the owl statue
 
         prairie_cave = Location()
-        prairie_cave_secret_exit = Location().connect(prairie_cave, AND(BOMB, OR(FEATHER, ROOSTER)))
+        prairie_cave_secret_exit = Location().connect(prairie_cave, AND(BOMB, OR(FEATHER, ROOSTER)), one_way=True)
+        prairie_cave = Location().connect(prairie_cave_secret_exit, OR(FEATHER, ROOSTER), one_way=True) # bomb walls are one-way        
         self._addEntrance("prairie_right_cave_top", ukuku_prairie, prairie_cave, None)
         self._addEntrance("prairie_right_cave_bottom", left_bay_area, prairie_cave, None)
         self._addEntrance("prairie_right_cave_high", prairie_plateau, prairie_cave_secret_exit, None)
@@ -282,7 +283,7 @@ class World:
         desert = Location().connect(animal_village, r.bush)  # Note: We moved the walrus blocking the desert.
         if options.owlstatues == "both" or options.owlstatues == "overworld":
             desert.add(OwlStatue(0x0CF))
-        desert_lanmola = Location().add(AnglerKey()).connect(desert, OR(BOW, SWORD, HOOKSHOT, MAGIC_ROD, BOOMERANG))
+        desert_lanmola = Location().add(AnglerKey()).connect(desert, r.attack_hookshot_no_bomb)
 
         animal_village_bombcave = Location()
         self._addEntrance("animal_cave", desert, animal_village_bombcave, BOMB)
@@ -386,7 +387,8 @@ class World:
         bridge_seashell = Location().add(Seashell(0x00C)).connect(outside_rooster_house, AND(OR(FEATHER, ROOSTER), POWER_BRACELET))  # seashell right of rooster house, there is a hole in the bridge
 
         multichest_cave = Location()
-        multichest_cave_secret = Location().connect(multichest_cave, BOMB)
+        multichest_cave_secret = Location().connect(multichest_cave, one_way=True) # bomb walls are one-way
+        multichest_cave.connect(multichest_cave_secret, BOMB, one_way=True)
         water_cave_hole = Location()  # Location with the hole that drops you onto the hearth piece under water
         if options.logic != "casual":
             water_cave_hole.connect(heartpiece_swim_cave, FLIPPERS, one_way=True)
@@ -463,8 +465,9 @@ class World:
             hookshot_cave.connect(hookshot_cave_chest, AND(FEATHER, PEGASUS_BOOTS)) # boots jump the gap to the chest
             graveyard_cave_left.connect(graveyard_cave_right, HOOKSHOT, one_way=True) # hookshot the block behind the stairs while over the pit
             swamp_chest.connect(swamp, None)  # Clip past the flower
-            self._addEntranceRequirement("d2", POWER_BRACELET) # clip the top wall to walk between the goponga flower and the wall
-            self._addEntranceRequirement("d2", COUNT(SWORD, 2)) # use l2 sword spin to kill goponga flowers
+            self._addEntranceRequirementEnter("d2", POWER_BRACELET) # clip the top wall to walk between the goponga flower and the wall
+            self._addEntranceRequirementEnter("d2", COUNT(SWORD, 2)) # use l2 sword spin to kill goponga flowers
+            self._addEntranceRequirementExit("d2", None) # Clip out at d2 entrance door
             swamp.connect(writes_hut_outside, HOOKSHOT, one_way=True) # hookshot the sign in front of writes hut
             graveyard_heartpiece.connect(graveyard_cave_right, FEATHER) # jump to the bottom right tile around the blocks
             graveyard_heartpiece.connect(graveyard_cave_right, OR(HOOKSHOT, BOOMERANG)) # push bottom block, wall clip and hookshot/boomerang corner to grab item


### PR DESCRIPTION
This fixes the issues presented in the #69 reviews, all in one commit, without my brainless self pushing to my own master branch and breaking things.

things changed:
- lanmola uses r.attack_hookshot_no_bomb
- multichest cave and martha's bay secret are one-way exits without bombs (fixes #68)
- you can always exit d2 with a wall clip from the door (hard logic)