### PR TITLE
Allowed loading a ROM without file IO

### DIFF
--- a/entityData.py
+++ b/entityData.py
@@ -555,7 +555,7 @@ class EntityData:
 if __name__ == "__main__":
     from rom import ROM
     import sys
-    rom = ROM(sys.argv[1])
+    rom = ROM(open(sys.argv[1], 'rb'))
     ed = EntityData(rom)
     for e in ed.entities:
         print(NAME[e.index], e.bowwow_eat_flag)

--- a/generator.py
+++ b/generator.py
@@ -113,7 +113,7 @@ def generateRom(args, settings, seed, logic, *, rnd=None, multiworld=None):
     patches.core.easyColorDungeonAccess(rom)
     patches.owl.removeOwlEvents(rom)
     patches.enemies.fixArmosKnightAsMiniboss(rom)
-    patches.bank3e.addBank3E(rom, seed)
+    patches.bank3e.addBank3E(rom, seed, settings)
     patches.bank3f.addBank3F(rom)
     patches.core.removeGhost(rom)
     patches.core.fixMarinFollower(rom)

--- a/generator.py
+++ b/generator.py
@@ -56,7 +56,7 @@ import hints
 # Function to generate a final rom, this patches the rom with all required patches
 def generateRom(args, settings, seed, logic, *, rnd=None, multiworld=None):
     print("Loading: %s" % (args.input_filename))
-    rom = ROMWithTables(args.input_filename)
+    rom = ROMWithTables(open(args.input_filename, 'rb'))
 
     pymods = []
     if args.pymod:

--- a/main.py
+++ b/main.py
@@ -87,7 +87,7 @@ def main(mainargs: Optional[List[str]] = None) -> None:
     if args.exportmap:
         import mapexport
         print(f"Loading: {args.input_filename}")
-        rom = ROMWithTables(args.input_filename)
+        rom = ROMWithTables(open(args.input_filename, 'rb'))
         mapexport.MapExport(rom).export_all()
         sys.exit(0)
 
@@ -108,7 +108,7 @@ def main(mainargs: Optional[List[str]] = None) -> None:
 
     if args.dump is not None or args.test:
         print("Loading: %s" % (args.input_filename))
-        roms = [ROMWithTables(f) for f in [args.input_filename] + args.dump]
+        roms = [ROMWithTables(open(f, 'rb')) for f in [args.input_filename] + args.dump]
 
         if args.spoilerformat == "none":
             args.spoilerformat = "console"

--- a/mapgen/__init__.py
+++ b/mapgen/__init__.py
@@ -99,7 +99,7 @@ def store_map(rom, the_map: Map):
 
 
 def generate(rom_filename, w, h):
-    rom = ROMWithTables(rom_filename)
+    rom = ROMWithTables(open(rom_filename, 'rb'))
     overworld.patchOverworldTilesets(rom)
     core.cleanup(rom)
     tilesets = loadTileInfo(rom)

--- a/patches/bank3e.py
+++ b/patches/bank3e.py
@@ -9,7 +9,7 @@ def hasBank3E(rom):
 
 # Bank $3E is used for large chunks of custom code.
 #   Mainly for new chest and dropped items handling.
-def addBank3E(rom, seed):
+def addBank3E(rom, seed, settings):
     # No default text for getting the bow, so use an unused slot.
     rom.texts[0x89] = formatText("Found the {BOW}!")
     rom.texts[0xD9] = formatText("Found the {BOOMERANG}!")  # owl text slot reuse
@@ -204,7 +204,12 @@ WriteToVRAM:
     # Put 20 rupees in all owls by default.
     rom.patch(0x3E, 0x3B16, "00" * 0x316, "1C" * 0x316)
 
-    rom.patch(0x3E, 0x2F00, "00" * len(seed), binascii.hexlify(seed))
+    shortSeed = seed[:0x20]
+    rom.patch(0x3E, 0x2F00, "00" * len(shortSeed), binascii.hexlify(shortSeed))
+
+    shortSettings = settings.getShortString().encode('utf-8')
+    rom.patch(0x3E, 0x2F20, "00", binascii.hexlify(len(shortSettings).to_bytes(1, 'little')))
+    rom.patch(0x3E, 0x2F21, "00" * len(shortSettings), binascii.hexlify(shortSettings))
 
     # Prevent the photo album from crashing due to serial interrupts
     rom.patch(0x28, 0x00D2, ASM("ld a, $09"), ASM("ld a, $01"))

--- a/rom.py
+++ b/rom.py
@@ -75,3 +75,7 @@ class ROM:
 
     def readHexSeed(self):
         return self.banks[0x3E][0x2F00:0x2F10].hex().upper()
+    
+    def readShortSettings(self):
+        length = self.banks[0x3E][0x2F20]
+        return self.banks[0x3E][0x2F21:0x2F21+length].decode('utf-8')

--- a/rom.py
+++ b/rom.py
@@ -5,15 +5,10 @@ h2b = binascii.unhexlify
 
 
 class ROM:
-    def __init__(self, filename=None, data=None):
-        assert filename != None or data != None
-
-        if filename != None:
-            data = open(filename, "rb").read()
-        #assert len(data) == 1024 * 1024
+    def __init__(self, filestream):
         self.banks = []
         for n in range(0x40):
-            self.banks.append(bytearray(data[n*0x4000:(n+1)*0x4000]))
+            self.banks.append(bytearray(filestream.read(0x4000)))
 
     def patch(self, bank_nr, addr, old, new, *, fill_nop=False):
         new = h2b(new)

--- a/rom.py
+++ b/rom.py
@@ -5,8 +5,11 @@ h2b = binascii.unhexlify
 
 
 class ROM:
-    def __init__(self, filename):
-        data = open(filename, "rb").read()
+    def __init__(self, filename=None, data=None):
+        assert filename != None or data != None
+
+        if filename != None:
+            data = open(filename, "rb").read()
         #assert len(data) == 1024 * 1024
         self.banks = []
         for n in range(0x40):

--- a/romTables.py
+++ b/romTables.py
@@ -180,8 +180,8 @@ class IndoorRoomSpriteData(PointerTable):
 
 
 class ROMWithTables(ROM):
-    def __init__(self, filename=None, data=None):
-        super().__init__(filename, data)
+    def __init__(self, filestream):
+        super().__init__(filestream)
 
         # Ability to patch any text in the game with different text
         self.texts = Texts(self)

--- a/romTables.py
+++ b/romTables.py
@@ -180,8 +180,8 @@ class IndoorRoomSpriteData(PointerTable):
 
 
 class ROMWithTables(ROM):
-    def __init__(self, filename):
-        super().__init__(filename)
+    def __init__(self, filename=None, data=None):
+        super().__init__(filename, data)
 
         # Ability to patch any text in the game with different text
         self.texts = Texts(self)


### PR DESCRIPTION
This makes the ROM constructor accept either a filename or the ROM bytes. Magpie's autotracker never knows were the ROM file is, it has it in memory.