### PR TITLE
Save short settings string to ROM

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -113,7 +113,7 @@ def generateRom(args, settings, seed, logic, *, rnd=None, multiworld=None):
     patches.core.easyColorDungeonAccess(rom)
     patches.owl.removeOwlEvents(rom)
     patches.enemies.fixArmosKnightAsMiniboss(rom)
-    patches.bank3e.addBank3E(rom, seed)
+    patches.bank3e.addBank3E(rom, seed, settings)
     patches.bank3f.addBank3F(rom)
     patches.core.removeGhost(rom)
     patches.core.fixMarinFollower(rom)

--- a/patches/bank3e.py
+++ b/patches/bank3e.py
@@ -9,7 +9,7 @@ def hasBank3E(rom):
 
 # Bank $3E is used for large chunks of custom code.
 #   Mainly for new chest and dropped items handling.
-def addBank3E(rom, seed):
+def addBank3E(rom, seed, settings):
     # No default text for getting the bow, so use an unused slot.
     rom.texts[0x89] = formatText("Found the {BOW}!")
     rom.texts[0xD9] = formatText("Found the {BOOMERANG}!")  # owl text slot reuse
@@ -204,7 +204,12 @@ WriteToVRAM:
     # Put 20 rupees in all owls by default.
     rom.patch(0x3E, 0x3B16, "00" * 0x316, "1C" * 0x316)
 
-    rom.patch(0x3E, 0x2F00, "00" * len(seed), binascii.hexlify(seed))
+    shortSeed = seed[:0x20]
+    rom.patch(0x3E, 0x2F00, "00" * len(shortSeed), binascii.hexlify(shortSeed))
+
+    shortSettings = settings.getShortString().encode('utf-8')
+    rom.patch(0x3E, 0x2F20, "00", binascii.hexlify(len(shortSettings).to_bytes(1, 'little')))
+    rom.patch(0x3E, 0x2F21, "00" * len(shortSettings), binascii.hexlify(shortSettings))
 
     # Prevent the photo album from crashing due to serial interrupts
     rom.patch(0x28, 0x00D2, ASM("ld a, $09"), ASM("ld a, $01"))

--- a/rom.py
+++ b/rom.py
@@ -72,3 +72,7 @@ class ROM:
 
     def readHexSeed(self):
         return self.banks[0x3E][0x2F00:0x2F10].hex().upper()
+    
+    def readShortSettings(self):
+        length = self.banks[0x3E][0x2F20]
+        return self.banks[0x3E][0x2F21:0x2F21+length].decode('utf-8')


### PR DESCRIPTION
This stores the settings short string in 3E:2F20. The seed is truncated to 0x20 bytes in case of a user defined seed. The first byte at 2F20 is the number of bytes in the string.