### PR TITLE
logic: bush fixes & new shorthands

### DIFF
--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -12,7 +12,7 @@ class World:
         mabe_village = Location()
         Location().add(HeartPiece(0x2A4)).connect(mabe_village, r.bush)  # well
         Location().add(FishingMinigame()).connect(mabe_village, AND(r.bush, COUNT("RUPEES", 20)))  # fishing game, hearth piece is directly done by the minigame.
-        Location().add(Seashell(0x0A3)).connect(mabe_village, r.bush)  # bushes below the shop
+        Location().add(Seashell(0x0A3)).connect(mabe_village, r.bush_no_boomerang)  # bushes below the shop
         Location().add(Seashell(0x0D2)).connect(mabe_village, PEGASUS_BOOTS)  # smash into tree next to lv1
         Location().add(Song(0x092)).connect(mabe_village, OCARINA)  # Marins song
         rooster_cave = Location()
@@ -164,8 +164,8 @@ class World:
         Location().add(Seashell(0x0A5)).connect(dungeon3_entrance, SHOVEL)  # above lv3
         dungeon3_entrance.connect(ukuku_prairie, None, one_way=True) # jump down ledge back to ukuku_prairie
 
-        prairie_island_seashell = Location().add(Seashell(0x0A6)).connect(ukuku_prairie, AND(FLIPPERS, r.bush))  # next to lv3
-        Location().add(Seashell(0x08B)).connect(ukuku_prairie, r.bush)  # next to seashell house
+        prairie_island_seashell = Location().add(Seashell(0x0A6)).connect(ukuku_prairie, AND(FLIPPERS, r.item_bush))  # next to lv3
+        Location().add(Seashell(0x08B)).connect(ukuku_prairie, r.item_bush)  # next to seashell house
         Location().add(Seashell(0x0A4)).connect(ukuku_prairie, PEGASUS_BOOTS)  # smash into tree next to phonehouse
         self._addEntrance("castle_jump_cave", ukuku_prairie, Location().add(Chest(0x1FD)), OR(AND(FEATHER, PEGASUS_BOOTS), ROOSTER)) # left of the castle, 5 holes turned into 3
         Location().add(Seashell(0x0B9)).connect(ukuku_prairie, POWER_BRACELET)  # under the rock
@@ -174,8 +174,8 @@ class World:
         left_bay_area.connect(ghost_hut_outside, OR(AND(FEATHER, PEGASUS_BOOTS), ROOSTER))
         self._addEntrance("prairie_low_phone", left_bay_area, None, None)
 
-        Location().add(Seashell(0x0E9)).connect(left_bay_area, r.bush)  # same screen as mermaid statue
-        tiny_island = Location().add(Seashell(0x0F8)).connect(left_bay_area, AND(OR(FLIPPERS, ROOSTER), r.bush))  # tiny island
+        Location().add(Seashell(0x0E9)).connect(left_bay_area, r.item_bush)  # same screen as mermaid statue
+        tiny_island = Location().add(Seashell(0x0F8)).connect(left_bay_area, AND(OR(FLIPPERS, ROOSTER), r.item_bush))  # tiny island
 
         prairie_plateau = Location()  # prairie plateau at the owl statue
         if options.owlstatues == "both" or options.owlstatues == "overworld":
@@ -238,7 +238,7 @@ class World:
         castle_courtyard = Location()
         castle_frontdoor = Location().connect(castle_courtyard, r.bush)
         castle_frontdoor.connect(ukuku_prairie, "CASTLE_BUTTON") # the button in the castle connector allows access to the castle grounds in ER
-        self._addEntrance("castle_secret_entrance", next_to_castle, castle_secret_entrance_right, OR(BOMB, BOOMERANG, MAGIC_POWDER, MAGIC_ROD, SWORD))
+        self._addEntrance("castle_secret_entrance", next_to_castle, castle_secret_entrance_right, r.pit_bush)
         self._addEntrance("castle_secret_exit", castle_courtyard, castle_secret_entrance_left, None)
 
         Location().add(HeartPiece(0x078)).connect(bay_water, FLIPPERS)  # in the moat of the castle
@@ -275,7 +275,7 @@ class World:
         animal_village.connect(ukuku_prairie, OR(HOOKSHOT, ROOSTER))
         animal_village_connector_left = Location()
         animal_village_connector_right = Location().connect(animal_village_connector_left, PEGASUS_BOOTS)
-        self._addEntrance("prairie_to_animal_connector", ukuku_prairie, animal_village_connector_left, OR(BOMB, BOOMERANG, MAGIC_POWDER, MAGIC_ROD, SWORD)) # passage under river blocked by bush
+        self._addEntrance("prairie_to_animal_connector", ukuku_prairie, animal_village_connector_left, r.pit_bush) # passage under river blocked by bush
         self._addEntrance("animal_to_prairie_connector", animal_village, animal_village_connector_right, None)
         if options.owlstatues == "both" or options.owlstatues == "overworld":
             animal_village.add(OwlStatue(0x0DA))
@@ -499,14 +499,14 @@ class World:
             graveyard_cave_left.connect(graveyard_heartpiece, BOMB, one_way=True) # bomb trigger the heartpiece from the left side
             graveyard_heartpiece.connect(graveyard_cave_right, None) # sideways block push from the right staircase.
 
-            prairie_island_seashell.connect(ukuku_prairie, AND(FEATHER, r.bush)) # jesus jump from right side, screen transition on top of the water to reach the island
+            prairie_island_seashell.connect(ukuku_prairie, AND(FEATHER, r.item_bush)) # jesus jump from right side, screen transition on top of the water to reach the island
             self._addEntranceRequirement("castle_jump_cave", FEATHER) # 1 pit buffer to clip bottom wall and jump across.
             left_bay_area.connect(ghost_hut_outside, FEATHER) # 1 pit buffer to get across
-            tiny_island.connect(left_bay_area, AND(FEATHER, r.bush)) # jesus jump around
+            tiny_island.connect(left_bay_area, AND(FEATHER, r.item_bush)) # jesus jump around
             bay_madbatter_connector_exit.connect(bay_madbatter_connector_entrance, FEATHER, one_way=True) # jesus jump (3 screen) through the underground passage leading to martha's bay mad batter
             self._addEntranceRequirement("prairie_madbatter_connector_entrance", AND(FEATHER, POWER_BRACELET)) # villa buffer into the top side of the bush, then pick it up
             
-            ukuku_prairie.connect(richard_maze, OR(BOMB, BOOMERANG, MAGIC_POWDER, MAGIC_ROD, SWORD), one_way=True) # break bushes on north side of the maze, and 1 pit buffer into the maze
+            ukuku_prairie.connect(richard_maze, r.pit_bush, one_way=True) # break bushes on north side of the maze, and 1 pit buffer into the maze
             fisher_under_bridge.connect(bay_water, AND(BOMB, FLIPPERS)) # can bomb trigger the item without having the hook 
             animal_village.connect(ukuku_prairie, FEATHER) # jesus jump
             below_right_taltal.connect(next_to_castle, FEATHER) # jesus jump (north of kanalet castle phonebooth)

--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -12,7 +12,7 @@ class World:
         mabe_village = Location()
         Location().add(HeartPiece(0x2A4)).connect(mabe_village, r.bush)  # well
         Location().add(FishingMinigame()).connect(mabe_village, AND(r.bush, COUNT("RUPEES", 20)))  # fishing game, hearth piece is directly done by the minigame.
-        Location().add(Seashell(0x0A3)).connect(mabe_village, r.bush_no_boomerang)  # bushes below the shop
+        Location().add(Seashell(0x0A3)).connect(mabe_village, r.bush)  # bushes below the shop
         Location().add(Seashell(0x0D2)).connect(mabe_village, PEGASUS_BOOTS)  # smash into tree next to lv1
         Location().add(Song(0x092)).connect(mabe_village, OCARINA)  # Marins song
         rooster_cave = Location()

--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -164,8 +164,8 @@ class World:
         Location().add(Seashell(0x0A5)).connect(dungeon3_entrance, SHOVEL)  # above lv3
         dungeon3_entrance.connect(ukuku_prairie, None, one_way=True) # jump down ledge back to ukuku_prairie
 
-        prairie_island_seashell = Location().add(Seashell(0x0A6)).connect(ukuku_prairie, AND(FLIPPERS, r.item_bush))  # next to lv3
-        Location().add(Seashell(0x08B)).connect(ukuku_prairie, r.item_bush)  # next to seashell house
+        prairie_island_seashell = Location().add(Seashell(0x0A6)).connect(ukuku_prairie, AND(FLIPPERS, r.bush))  # next to lv3
+        Location().add(Seashell(0x08B)).connect(ukuku_prairie, r.bush)  # next to seashell house
         Location().add(Seashell(0x0A4)).connect(ukuku_prairie, PEGASUS_BOOTS)  # smash into tree next to phonehouse
         self._addEntrance("castle_jump_cave", ukuku_prairie, Location().add(Chest(0x1FD)), OR(AND(FEATHER, PEGASUS_BOOTS), ROOSTER)) # left of the castle, 5 holes turned into 3
         Location().add(Seashell(0x0B9)).connect(ukuku_prairie, POWER_BRACELET)  # under the rock
@@ -174,8 +174,8 @@ class World:
         left_bay_area.connect(ghost_hut_outside, OR(AND(FEATHER, PEGASUS_BOOTS), ROOSTER))
         self._addEntrance("prairie_low_phone", left_bay_area, None, None)
 
-        Location().add(Seashell(0x0E9)).connect(left_bay_area, r.item_bush)  # same screen as mermaid statue
-        tiny_island = Location().add(Seashell(0x0F8)).connect(left_bay_area, AND(OR(FLIPPERS, ROOSTER), r.item_bush))  # tiny island
+        Location().add(Seashell(0x0E9)).connect(left_bay_area, r.bush)  # same screen as mermaid statue
+        tiny_island = Location().add(Seashell(0x0F8)).connect(left_bay_area, AND(OR(FLIPPERS, ROOSTER), r.bush))  # tiny island
 
         prairie_plateau = Location()  # prairie plateau at the owl statue
         if options.owlstatues == "both" or options.owlstatues == "overworld":
@@ -499,10 +499,10 @@ class World:
             graveyard_cave_left.connect(graveyard_heartpiece, BOMB, one_way=True) # bomb trigger the heartpiece from the left side
             graveyard_heartpiece.connect(graveyard_cave_right, None) # sideways block push from the right staircase.
 
-            prairie_island_seashell.connect(ukuku_prairie, AND(FEATHER, r.item_bush)) # jesus jump from right side, screen transition on top of the water to reach the island
+            prairie_island_seashell.connect(ukuku_prairie, AND(FEATHER, r.bush)) # jesus jump from right side, screen transition on top of the water to reach the island
             self._addEntranceRequirement("castle_jump_cave", FEATHER) # 1 pit buffer to clip bottom wall and jump across.
             left_bay_area.connect(ghost_hut_outside, FEATHER) # 1 pit buffer to get across
-            tiny_island.connect(left_bay_area, AND(FEATHER, r.item_bush)) # jesus jump around
+            tiny_island.connect(left_bay_area, AND(FEATHER, r.bush)) # jesus jump around
             bay_madbatter_connector_exit.connect(bay_madbatter_connector_entrance, FEATHER, one_way=True) # jesus jump (3 screen) through the underground passage leading to martha's bay mad batter
             self._addEntranceRequirement("prairie_madbatter_connector_entrance", AND(FEATHER, POWER_BRACELET)) # villa buffer into the top side of the bush, then pick it up
             

--- a/logic/requirements.py
+++ b/logic/requirements.py
@@ -254,7 +254,7 @@ def isConsumable(item) -> bool:
 class RequirementsSettings:
     def __init__(self, options):
         self.bush = OR(SWORD, MAGIC_POWDER, MAGIC_ROD, POWER_BRACELET, BOOMERANG)
-        self.item_bush = OR(SWORD, MAGIC_POWDER, MAGIC_ROD, POWER_BRACELET) # unique
+        self.bush_no_boomerang = OR(SWORD, MAGIC_POWDER, MAGIC_ROD, POWER_BRACELET) # mabe bush field, maybe others
         self.pit_bush = OR(SWORD, MAGIC_POWDER, MAGIC_ROD, BOOMERANG, BOMB) # unique
         self.attack = OR(SWORD, BOMB, BOW, MAGIC_ROD, BOOMERANG)
         self.attack_hookshot = OR(SWORD, BOMB, BOW, MAGIC_ROD, BOOMERANG, HOOKSHOT) # switches, hinox, shrouded stalfos

--- a/logic/requirements.py
+++ b/logic/requirements.py
@@ -254,6 +254,8 @@ def isConsumable(item) -> bool:
 class RequirementsSettings:
     def __init__(self, options):
         self.bush = OR(SWORD, MAGIC_POWDER, MAGIC_ROD, POWER_BRACELET, BOOMERANG)
+        self.item_bush = OR(SWORD, MAGIC_POWDER, MAGIC_ROD, POWER_BRACELET) # unique
+        self.pit_bush = OR(SWORD, MAGIC_POWDER, MAGIC_ROD, BOOMERANG, BOMB) # unique
         self.attack = OR(SWORD, BOMB, BOW, MAGIC_ROD, BOOMERANG)
         self.attack_hookshot = OR(SWORD, BOMB, BOW, MAGIC_ROD, BOOMERANG, HOOKSHOT) # switches, hinox, shrouded stalfos
         self.attack_hookshot_powder = OR(SWORD, BOMB, BOW, MAGIC_ROD, BOOMERANG, HOOKSHOT, MAGIC_POWDER) # zols, keese, moldorm

--- a/logic/requirements.py
+++ b/logic/requirements.py
@@ -254,7 +254,6 @@ def isConsumable(item) -> bool:
 class RequirementsSettings:
     def __init__(self, options):
         self.bush = OR(SWORD, MAGIC_POWDER, MAGIC_ROD, POWER_BRACELET, BOOMERANG)
-        self.bush_no_boomerang = OR(SWORD, MAGIC_POWDER, MAGIC_ROD, POWER_BRACELET) # mabe bush field, maybe others
         self.pit_bush = OR(SWORD, MAGIC_POWDER, MAGIC_ROD, BOOMERANG, BOMB) # unique
         self.attack = OR(SWORD, BOMB, BOW, MAGIC_ROD, BOOMERANG)
         self.attack_hookshot = OR(SWORD, BOMB, BOW, MAGIC_ROD, BOOMERANG, HOOKSHOT) # switches, hinox, shrouded stalfos


### PR DESCRIPTION
apparently item bushes are weird, too! boomerang doesnt work on them. this PR adds shorthand for pit/stair bushes and item bushes, and implements them wherever i could find the place for it.