### PR TITLE
logic: introduce jesus rooster

### DIFF
--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -502,12 +502,18 @@ class World:
             graveyard_cave_left.connect(graveyard_heartpiece, BOMB, one_way=True) # bomb trigger the heartpiece from the left side
             graveyard_heartpiece.connect(graveyard_cave_right, None) # sideways block push from the right staircase.
 
-            prairie_island_seashell.connect(ukuku_prairie, AND(FEATHER, r.bush)) # jesus jump from right side, screen transition on top of the water to reach the island
+            prairie_island_seashell.connect(ukuku_prairie, AND(OR(FEATHER, ROOSTER), r.bush)) # jesus jump/rooster from right side, screen transition on top of the water to reach the island
+            d6_armos_island.connect(ukuku_prairie, ROOSTER) # jesus rooster (2 transition) from seashell mansion to armos island
             self._addEntranceRequirement("castle_jump_cave", FEATHER) # 1 pit buffer to clip bottom wall and jump across.
             left_bay_area.connect(ghost_hut_outside, FEATHER) # 1 pit buffer to get across
             tiny_island.connect(left_bay_area, AND(FEATHER, r.bush)) # jesus jump around
-            bay_madbatter_connector_exit.connect(bay_madbatter_connector_entrance, FEATHER, one_way=True) # jesus jump (3 screen) through the underground passage leading to martha's bay mad batter
-            self._addEntranceRequirement("prairie_madbatter_connector_entrance", AND(FEATHER, POWER_BRACELET)) # villa buffer into the top side of the bush, then pick it up
+            bay_madbatter_connector_exit.connect(bay_madbatter_connector_entrance, OR(FEATHER, ROOSTER), one_way=True) # jesus jump/rooster (3 screen) through the underground passage leading to martha's bay mad batter
+            self._addEntranceRequirement("prairie_madbatter_connector_entrance", AND(OR(FEATHER, ROOSTER), POWER_BRACELET)) # villa buffer into the top side of the bush, then pick it up
+
+            # jesus rooster across bay area
+            left_bay_area.connect(bay_water, ROOSTER)
+            animal_village.connect(bay_water, ROOSTER)
+            ukuku_prairie.connect(bay_water, ROOSTER, one_way=True)
             
             ukuku_prairie.connect(richard_maze, OR(SWORD, AND(MAGIC_POWDER, MAX_POWDER_UPGRADE), MAGIC_ROD, BOOMERANG, BOMB), one_way=True) # break bushes on north side of the maze, and 1 pit buffer into the maze
             fisher_under_bridge.connect(bay_water, AND(BOMB, FLIPPERS)) # up-most left wall is a pit: bomb trigger with it 
@@ -515,21 +521,23 @@ class World:
             below_right_taltal.connect(next_to_castle, FEATHER) # jesus jump (north of kanalet castle phonebooth)
             animal_village_connector_right.connect(animal_village_connector_left, FEATHER) # text clip past the obstacles (can go both ways), feather to wall clip the obstacle without triggering text or shaq jump in bottom right corner if text is off
             animal_village_bombcave_heartpiece.connect(animal_village_bombcave, AND(BOMB, OR(HOOKSHOT, FEATHER, PEGASUS_BOOTS))) # bomb trigger from right side, corner walking top right pit is stupid so hookshot or boots added
-            animal_village_bombcave_heartpiece.connect(animal_village_bombcave,  FEATHER) # villa buffer across the pits
+            animal_village_bombcave_heartpiece.connect(animal_village_bombcave, FEATHER) # villa buffer across the pits
 
-            d6_entrance.connect(ukuku_prairie, FEATHER, one_way=True) # jesus jump (2 screen) from d6 entrance bottom ledge to ukuku prairie
-            d6_entrance.connect(armos_fairy_entrance, FEATHER, one_way=True) # jesus jump (2 screen) from d6 entrance top ledge to armos fairy entrance
-            d6_connector_left.connect(d6_connector_right, FEATHER) # jesus jump over water <-> left side is jumpable, or villa buffer if it's easier for you
-            armos_fairy_entrance.connect(d6_armos_island, FEATHER, one_way=True) # jesus jump from top (fairy bomb cave) to armos island
-            armos_fairy_entrance.connect(raft_exit, FEATHER) # jesus jump (2-ish screen) from fairy cave to lower raft connector
+            d6_entrance.connect(ukuku_prairie, OR(FEATHER, ROOSTER), one_way=True) # jesus jump/rooster (2 screen) from d6 entrance bottom ledge to ukuku prairie
+            d6_entrance.connect(armos_fairy_entrance, OR(FEATHER, ROOSTER), one_way=True) # jesus jump/rooster (2 screen) from d6 entrance top ledge to armos fairy entrance
+            d6_connector_left.connect(d6_connector_right, FEATHER) # jesus jump over water; left side is jumpable, or villa buffer if it's easier for you
+            armos_fairy_entrance.connect(d6_armos_island, OR(FEATHER, ROOSTER), one_way=True) # jesus jump/rooster from top (fairy bomb cave) to armos island
+            armos_fairy_entrance.connect(raft_exit, OR(FEATHER, ROOSTER)) # jesus jump/rooster (2-ish screen) from fairy cave to lower raft connector
             self._addEntranceRequirementEnter("obstacle_cave_entrance", HOOKSHOT) # clip past the rocks in front of obstacle cave entrance
             obstacle_cave_inside_chest.connect(obstacle_cave_inside, FEATHER) # jump to the rightmost pits + 1 pit buffer to jump across
             obstacle_cave_exit.connect(obstacle_cave_inside, FEATHER) #  1 pit buffer above boots crystals to get past
             lower_right_taltal.connect(hibiscus_item, AND(TRADING_ITEM_PINEAPPLE, BOMB), one_way=True) # bomb trigger papahl from below ledge, requires pineapple
             
-            self._addEntranceRequirement("heartpiece_swim_cave", FEATHER)  # jesus jump into the cave entrance after jumping down the ledge, can jesus jump back to the ladder 1 screen below
-            self._addEntranceRequirement("mambo", FEATHER)  # jesus jump from (unlocked) d4 entrance to mambo's cave entrance
-            outside_raft_house.connect(below_right_taltal, FEATHER, one_way=True) # jesus jump from the ledge at raft to the staircase 1 screen south
+            self._addEntranceRequirement("heartpiece_swim_cave", OR(FEATHER, ROOSTER))  # jesus jump/rooster into the cave entrance after jumping down the ledge, can jesus jump/rooster back to the ladder 1 screen below
+            self._addEntranceRequirement("mambo", OR(FEATHER, ROOSTER))  # jesus jump/rooster from d4 entrance to mambo's cave entrance
+            outside_raft_house.connect(below_right_taltal, OR(FEATHER, ROOSTER), one_way=True) # jesus jump/rooster from the ledge at raft to the staircase 1 screen south
+            d4_entrance.connect(below_right_taltal, ROOSTER) # jesus rooster (4 transitions) to staircase below damp cave
+            lower_right_taltal.connect(below_right_taltal, ROOSTER, one_way=True) # rooster to waterfall ledges, jump off, enter and exit s+q menu to regain pauses, jesus rooster 3 transitions to staircase below damp cave
 
             self._addEntranceRequirement("multichest_left", FEATHER) # jesus jump past staircase leading up the mountain 
             outside_rooster_house.connect(lower_right_taltal, FEATHER) # jesus jump (1 or 2 screen depending if angler key is used) to staircase leading up the mountain
@@ -569,7 +577,7 @@ class World:
             left_bay_area.connect(bay_water, FEATHER) # jesus jump (can always reach bay_water with jesus jumping from every way to enter bay_water, so no one_way)
             animal_village.connect(bay_water, FEATHER) # jesus jump (can always reach bay_water with jesus jumping from every way to enter bay_water, so no one_way)
             ukuku_prairie.connect(bay_water, FEATHER, one_way=True) # jesus jump
-            bay_water.connect(d5_entrance, FEATHER) # jesus jump into d5 entrance (wall clip), wall clip + jesus jump to get out
+            bay_water.connect(d5_entrance, OR(FEATHER, ROOSTER)) # jesus jump/rooster into d5 entrance (wall clip), wall clip + jesus jump to get out
             
             crow_gold_leaf.connect(castle_courtyard, BOMB) # bird on tree at left side kanalet, place a bomb against the tree and the crow flies off. With well placed second bomb the crow can be killed
             mermaid_statue.connect(animal_village, AND(TRADING_ITEM_SCALE, FEATHER)) # early mermaid statue by buffering on top of the right ledge, then superjumping to the left (horizontal pixel perfect)
@@ -585,8 +593,8 @@ class World:
             lower_right_taltal.connect(below_right_taltal, FEATHER, one_way=True) # jesus jump to waterfall ledges, jump off, enter and exit s+q menu to regain pauses, then jesus jump 4 screens to staircase below damp cave
             
             if options.entranceshuffle in ("default", "simple"): # connector cave from armos d6 area to raft shop may not be randomized to add a flippers path since flippers stop you from jesus jumping
-                below_right_taltal.connect(raft_game, AND(FEATHER, r.attack_hookshot_powder), one_way=True) # jesus jump from heartpiece water cave, around the island and clip past the diagonal gap in the rock, then jesus jump all the way down the waterfall to the chests (attack req for hardlock flippers+feather scenario)
-            outside_raft_house.connect(below_right_taltal, AND(FEATHER, PEGASUS_BOOTS)) #superjump from ledge left to right, can buffer to land on ledge instead of water, then superjump right which is pixel perfect
+                below_right_taltal.connect(raft_game, AND(OR(FEATHER, ROOSTER), r.attack_hookshot_powder), one_way=True) # jesus jump/rooster from heartpiece water cave, around the island and clip past the diagonal gap in the rock, then jesus jump/rooster all the way down the waterfall to the chests (attack req for hardlock flippers+feather scenario)
+            outside_raft_house.connect(below_right_taltal, AND(FEATHER, PEGASUS_BOOTS)) # superjump from ledge left to right, can buffer to land on ledge instead of water, then superjump right which is pixel perfect
             bridge_seashell.connect(outside_rooster_house, AND(PEGASUS_BOOTS, POWER_BRACELET)) # boots bonk
             bird_key.connect(bird_cave, AND(FEATHER, PEGASUS_BOOTS)) # boots jump above wall, use multiple pit buffers to get across
             mountain_bridge_staircase.connect(outside_rooster_house, OR(PEGASUS_BOOTS, FEATHER)) # cross bridge to staircase with pit buffer to clip bottom wall and jump or boots bonk across

--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -502,18 +502,12 @@ class World:
             graveyard_cave_left.connect(graveyard_heartpiece, BOMB, one_way=True) # bomb trigger the heartpiece from the left side
             graveyard_heartpiece.connect(graveyard_cave_right, None) # sideways block push from the right staircase.
 
-            prairie_island_seashell.connect(ukuku_prairie, AND(OR(FEATHER, ROOSTER), r.bush)) # jesus jump/rooster from right side, screen transition on top of the water to reach the island
-            d6_armos_island.connect(ukuku_prairie, ROOSTER) # jesus rooster (2 transition) from seashell mansion to armos island
+            prairie_island_seashell.connect(ukuku_prairie, AND(FEATHER, r.bush)) # jesus jump from right side, screen transition on top of the water to reach the island
             self._addEntranceRequirement("castle_jump_cave", FEATHER) # 1 pit buffer to clip bottom wall and jump across.
             left_bay_area.connect(ghost_hut_outside, FEATHER) # 1 pit buffer to get across
             tiny_island.connect(left_bay_area, AND(FEATHER, r.bush)) # jesus jump around
-            bay_madbatter_connector_exit.connect(bay_madbatter_connector_entrance, OR(FEATHER, ROOSTER), one_way=True) # jesus jump/rooster (3 screen) through the underground passage leading to martha's bay mad batter
-            self._addEntranceRequirement("prairie_madbatter_connector_entrance", AND(OR(FEATHER, ROOSTER), POWER_BRACELET)) # villa buffer into the top side of the bush, then pick it up
-
-            # jesus rooster across bay area
-            left_bay_area.connect(bay_water, ROOSTER)
-            animal_village.connect(bay_water, ROOSTER)
-            ukuku_prairie.connect(bay_water, ROOSTER, one_way=True)
+            bay_madbatter_connector_exit.connect(bay_madbatter_connector_entrance, FEATHER, one_way=True) # jesus jump (3 screen) through the underground passage leading to martha's bay mad batter
+            self._addEntranceRequirement("prairie_madbatter_connector_entrance", AND(FEATHER, POWER_BRACELET)) # villa buffer into the top side of the bush, then pick it up
             
             ukuku_prairie.connect(richard_maze, OR(SWORD, AND(MAGIC_POWDER, MAX_POWDER_UPGRADE), MAGIC_ROD, BOOMERANG, BOMB), one_way=True) # break bushes on north side of the maze, and 1 pit buffer into the maze
             fisher_under_bridge.connect(bay_water, AND(BOMB, FLIPPERS)) # up-most left wall is a pit: bomb trigger with it 
@@ -521,23 +515,21 @@ class World:
             below_right_taltal.connect(next_to_castle, FEATHER) # jesus jump (north of kanalet castle phonebooth)
             animal_village_connector_right.connect(animal_village_connector_left, FEATHER) # text clip past the obstacles (can go both ways), feather to wall clip the obstacle without triggering text or shaq jump in bottom right corner if text is off
             animal_village_bombcave_heartpiece.connect(animal_village_bombcave, AND(BOMB, OR(HOOKSHOT, FEATHER, PEGASUS_BOOTS))) # bomb trigger from right side, corner walking top right pit is stupid so hookshot or boots added
-            animal_village_bombcave_heartpiece.connect(animal_village_bombcave, FEATHER) # villa buffer across the pits
+            animal_village_bombcave_heartpiece.connect(animal_village_bombcave,  FEATHER) # villa buffer across the pits
 
-            d6_entrance.connect(ukuku_prairie, OR(FEATHER, ROOSTER), one_way=True) # jesus jump/rooster (2 screen) from d6 entrance bottom ledge to ukuku prairie
-            d6_entrance.connect(armos_fairy_entrance, OR(FEATHER, ROOSTER), one_way=True) # jesus jump/rooster (2 screen) from d6 entrance top ledge to armos fairy entrance
+            d6_entrance.connect(ukuku_prairie, FEATHER, one_way=True) # jesus jump (2 screen) from d6 entrance bottom ledge to ukuku prairie
+            d6_entrance.connect(armos_fairy_entrance, FEATHER, one_way=True) # jesus jump (2 screen) from d6 entrance top ledge to armos fairy entrance
             d6_connector_left.connect(d6_connector_right, FEATHER) # jesus jump over water; left side is jumpable, or villa buffer if it's easier for you
-            armos_fairy_entrance.connect(d6_armos_island, OR(FEATHER, ROOSTER), one_way=True) # jesus jump/rooster from top (fairy bomb cave) to armos island
-            armos_fairy_entrance.connect(raft_exit, OR(FEATHER, ROOSTER)) # jesus jump/rooster (2-ish screen) from fairy cave to lower raft connector
+            armos_fairy_entrance.connect(d6_armos_island, FEATHER, one_way=True) # jesus jump from top (fairy bomb cave) to armos island
+            armos_fairy_entrance.connect(raft_exit, FEATHER) # jesus jump (2-ish screen) from fairy cave to lower raft connector
             self._addEntranceRequirementEnter("obstacle_cave_entrance", HOOKSHOT) # clip past the rocks in front of obstacle cave entrance
             obstacle_cave_inside_chest.connect(obstacle_cave_inside, FEATHER) # jump to the rightmost pits + 1 pit buffer to jump across
             obstacle_cave_exit.connect(obstacle_cave_inside, FEATHER) #  1 pit buffer above boots crystals to get past
             lower_right_taltal.connect(hibiscus_item, AND(TRADING_ITEM_PINEAPPLE, BOMB), one_way=True) # bomb trigger papahl from below ledge, requires pineapple
             
-            self._addEntranceRequirement("heartpiece_swim_cave", OR(FEATHER, ROOSTER))  # jesus jump/rooster into the cave entrance after jumping down the ledge, can jesus jump/rooster back to the ladder 1 screen below
-            self._addEntranceRequirement("mambo", OR(FEATHER, ROOSTER))  # jesus jump/rooster from d4 entrance to mambo's cave entrance
-            outside_raft_house.connect(below_right_taltal, OR(FEATHER, ROOSTER), one_way=True) # jesus jump/rooster from the ledge at raft to the staircase 1 screen south
-            d4_entrance.connect(below_right_taltal, ROOSTER, one_way=True) # jesus rooster (4 transitions) to staircase below damp cave
-            lower_right_taltal.connect(below_right_taltal, ROOSTER, one_way=True) # jump off ledge above d4, jesus rooster 4 transitions to staircase below damp cave
+            self._addEntranceRequirement("heartpiece_swim_cave", FEATHER)  # jesus jump into the cave entrance after jumping down the ledge, can jesus jump back to the ladder 1 screen below
+            self._addEntranceRequirement("mambo", FEATHER)  # jesus jump from (unlocked) d4 entrance to mambo's cave entrance
+            outside_raft_house.connect(below_right_taltal, FEATHER, one_way=True) # jesus jump from the ledge at raft to the staircase 1 screen south
 
             self._addEntranceRequirement("multichest_left", FEATHER) # jesus jump past staircase leading up the mountain 
             outside_rooster_house.connect(lower_right_taltal, FEATHER) # jesus jump (1 or 2 screen depending if angler key is used) to staircase leading up the mountain
@@ -574,27 +566,42 @@ class World:
             self._addEntranceRequirementExit("prairie_madbatter_connector_entrance", AND(PEGASUS_BOOTS, r.bush)) # if exiting, you can pick up the bushes by normal means and boots bonk across the bottom wall
 
             # bay_water connectors, only left_bay_area, ukuku_prairie and animal_village have to be connected with jesus jumps. below_right_taltal, d6_armos_island and armos_fairy_entrance are accounted for via ukuku prairie in glitch logic
-            left_bay_area.connect(bay_water, FEATHER) # jesus jump (can always reach bay_water with jesus jumping from every way to enter bay_water, so no one_way)
-            animal_village.connect(bay_water, FEATHER) # jesus jump (can always reach bay_water with jesus jumping from every way to enter bay_water, so no one_way)
-            ukuku_prairie.connect(bay_water, FEATHER, one_way=True) # jesus jump
-            bay_water.connect(d5_entrance, OR(FEATHER, ROOSTER)) # jesus jump/rooster into d5 entrance (wall clip), wall clip + jesus jump to get out
+            left_bay_area.connect(bay_water, OR(FEATHER, ROOSTER)) # jesus jump (can always reach bay_water with jesus jumping from every way to enter bay_water, so no one_way)
+            animal_village.connect(bay_water, OR(FEATHER, ROOSTER)) # jesus jump (can always reach bay_water with jesus jumping from every way to enter bay_water, so no one_way)
+            ukuku_prairie.connect(bay_water, OR(FEATHER, ROOSTER), one_way=True) # jesus jump
+            bay_water.connect(d5_entrance, OR(FEATHER, ROOSTER)) # jesus jump into d5 entrance (wall clip), wall clip + jesus jump to get out
             
             crow_gold_leaf.connect(castle_courtyard, BOMB) # bird on tree at left side kanalet, place a bomb against the tree and the crow flies off. With well placed second bomb the crow can be killed
             mermaid_statue.connect(animal_village, AND(TRADING_ITEM_SCALE, FEATHER)) # early mermaid statue by buffering on top of the right ledge, then superjumping to the left (horizontal pixel perfect)
             animal_village_bombcave_heartpiece.connect(animal_village_bombcave, PEGASUS_BOOTS) # boots bonk across bottom wall (both at entrance and in item room)
 
-            d6_armos_island.connect(ukuku_prairie, FEATHER) # jesus jump (3 screen) from seashell mansion to armos island
+            d6_armos_island.connect(ukuku_prairie, OR(FEATHER, ROOSTER)) # jesus jump/rooster (3 screen) from seashell mansion to armos island
             armos_fairy_entrance.connect(d6_armos_island, PEGASUS_BOOTS, one_way=True) # jesus jump from top (fairy bomb cave) to armos island with fast falling 
             d6_connector_right.connect(d6_connector_left, PEGASUS_BOOTS) # boots bonk across bottom wall at water and pits (can do both ways)
             
             obstacle_cave_entrance.connect(obstacle_cave_inside, OR(HOOKSHOT, AND(FEATHER, PEGASUS_BOOTS, OR(SWORD, MAGIC_ROD, BOW)))) # get past crystal rocks by hookshotting into top pushable block, or boots dashing into top wall where the pushable block is to superjump down
             obstacle_cave_entrance.connect(obstacle_cave_inside, AND(PEGASUS_BOOTS, ROOSTER)) # get past crystal rocks pushing the top pushable block, then boots dashing up picking up the rooster before bonking. Pause buffer until rooster is fully picked up then throw it down before bonking into wall
-            d4_entrance.connect(below_right_taltal, FEATHER, one_way=true) # jesus jump 5 screens to staircase below damp cave
-            lower_right_taltal.connect(below_right_taltal, FEATHER, one_way=True) # jesus jump to waterfall ledges, jump off, enter and exit s+q menu to regain pauses, then jesus jump 4 screens to staircase below damp cave
+            d4_entrance.connect(below_right_taltal, OR(FEATHER, ROOSTER), one_way=True) # jesus jump 5 screens to staircase below damp cave
+            lower_right_taltal.connect(below_right_taltal, OR(FEATHER, ROOSTER), one_way=True) # jesus jump to upper ledges, jump off, enter and exit s+q menu to regain pauses, then jesus jump 4 screens to staircase below damp cave
+
+            # jesus rooster section
+            prairie_island_seashell.connect(ukuku_prairie, AND(ROOSTER, r.bush)) # jesus jump from right side, screen transition on top of the water to reach the island
+            bay_madbatter_connector_exit.connect(bay_madbatter_connector_entrance, ROOSTER, one_way=True) # jesus jump (3 screen) through the underground passage leading to martha's bay mad batter
+            self._addEntranceRequirement("prairie_madbatter_connector_entrance", AND(ROOSTER, POWER_BRACELET)) # villa buffer into the top side of the bush, then pick it up
+            d6_entrance.connect(ukuku_prairie, ROOSTER, one_way=True) # jesus jump (2 screen) from d6 entrance bottom ledge to ukuku prairie
+            d6_entrance.connect(armos_fairy_entrance, ROOSTER, one_way=True) # jesus jump (2 screen) from d6 entrance top ledge to armos fairy entrance
+            d6_connector_left.connect(d6_connector_right, ROOSTER) # jesus jump over water <-> left side is jumpable, or villa buffer if it's easier for you
+            armos_fairy_entrance.connect(d6_armos_island, ROOSTER, one_way=True) # jesus jump from top (fairy bomb cave) to armos island
+            armos_fairy_entrance.connect(raft_exit, ROOSTER) # jesus jump (2-ish screen) from fairy cave to lower raft connector
+            self._addEntranceRequirement("heartpiece_swim_cave", ROOSTER)  # jesus jump into the cave entrance after jumping down the ledge, can jesus jump back to the ladder 1 screen below
+            self._addEntranceRequirement("mambo", ROOSTER)  # jesus jump from (unlocked) d4 entrance to mambo's cave entrance
+            outside_raft_house.connect(below_right_taltal, ROOSTER, one_way=True) # jesus jump from the ledge at raft to the staircase 1 screen south
+            self._addEntranceRequirement("multichest_left", ROOSTER) # jesus jump past staircase leading up the mountain 
+            outside_rooster_house.connect(lower_right_taltal, ROOSTER) # jesus jump down to staircase below damp cave
             
             if options.entranceshuffle in ("default", "simple"): # connector cave from armos d6 area to raft shop may not be randomized to add a flippers path since flippers stop you from jesus jumping
-                below_right_taltal.connect(raft_game, AND(OR(FEATHER, ROOSTER), r.attack_hookshot_powder), one_way=True) # jesus jump/rooster from heartpiece water cave, around the island and clip past the diagonal gap in the rock, then jesus jump/rooster all the way down the waterfall to the chests (attack req for hardlock flippers+feather scenario)
-            outside_raft_house.connect(below_right_taltal, AND(FEATHER, PEGASUS_BOOTS)) # superjump from ledge left to right, can buffer to land on ledge instead of water, then superjump right which is pixel perfect
+                below_right_taltal.connect(raft_game, AND(OR(FEATHER, ROOSTER), r.attack_hookshot_powder), one_way=True) # jesus jump from heartpiece water cave, around the island and clip past the diagonal gap in the rock, then jesus jump all the way down the waterfall to the chests (attack req for hardlock flippers+feather scenario)
+            outside_raft_house.connect(below_right_taltal, AND(FEATHER, PEGASUS_BOOTS)) #superjump from ledge left to right, can buffer to land on ledge instead of water, then superjump right which is pixel perfect
             bridge_seashell.connect(outside_rooster_house, AND(PEGASUS_BOOTS, POWER_BRACELET)) # boots bonk
             bird_key.connect(bird_cave, AND(FEATHER, PEGASUS_BOOTS)) # boots jump above wall, use multiple pit buffers to get across
             mountain_bridge_staircase.connect(outside_rooster_house, OR(PEGASUS_BOOTS, FEATHER)) # cross bridge to staircase with pit buffer to clip bottom wall and jump or boots bonk across

--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -597,7 +597,7 @@ class World:
             self._addEntranceRequirement("mambo", ROOSTER)  # jesus jump from (unlocked) d4 entrance to mambo's cave entrance
             outside_raft_house.connect(below_right_taltal, ROOSTER, one_way=True) # jesus jump from the ledge at raft to the staircase 1 screen south
             self._addEntranceRequirement("multichest_left", ROOSTER) # jesus jump past staircase leading up the mountain 
-            outside_rooster_house.connect(lower_right_taltal, ROOSTER) # jesus jump down to staircase below damp cave
+            outside_rooster_house.connect(lower_right_taltal, ROOSTER, one_way=True) # jesus jump down to staircase below damp cave
             
             if options.entranceshuffle in ("default", "simple"): # connector cave from armos d6 area to raft shop may not be randomized to add a flippers path since flippers stop you from jesus jumping
                 below_right_taltal.connect(raft_game, AND(OR(FEATHER, ROOSTER), r.attack_hookshot_powder), one_way=True) # jesus jump from heartpiece water cave, around the island and clip past the diagonal gap in the rock, then jesus jump all the way down the waterfall to the chests (attack req for hardlock flippers+feather scenario)

--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -507,7 +507,7 @@ class World:
             left_bay_area.connect(ghost_hut_outside, FEATHER) # 1 pit buffer to get across
             tiny_island.connect(left_bay_area, AND(FEATHER, r.bush)) # jesus jump around
             bay_madbatter_connector_exit.connect(bay_madbatter_connector_entrance, FEATHER, one_way=True) # jesus jump (3 screen) through the underground passage leading to martha's bay mad batter
-            self._addEntranceRequirement("prairie_madbatter_connector_entrance", AND(FEATHER, POWER_BRACELET)) # villa buffer into the top side of the bush, then pick it up
+            self._addEntranceRequirement("prairie_madbatter_connector_entrance", AND(OR(FEATHER, ROOSTER), POWER_BRACELET)) # villa buffer into the top side of the bush, then pick it up
             
             ukuku_prairie.connect(richard_maze, OR(SWORD, AND(MAGIC_POWDER, MAX_POWDER_UPGRADE), MAGIC_ROD, BOOMERANG, BOMB), one_way=True) # break bushes on north side of the maze, and 1 pit buffer into the maze
             fisher_under_bridge.connect(bay_water, AND(BOMB, FLIPPERS)) # up-most left wall is a pit: bomb trigger with it 
@@ -566,11 +566,13 @@ class World:
             self._addEntranceRequirementExit("prairie_madbatter_connector_entrance", AND(PEGASUS_BOOTS, r.bush)) # if exiting, you can pick up the bushes by normal means and boots bonk across the bottom wall
 
             # bay_water connectors, only left_bay_area, ukuku_prairie and animal_village have to be connected with jesus jumps. below_right_taltal, d6_armos_island and armos_fairy_entrance are accounted for via ukuku prairie in glitch logic
-            left_bay_area.connect(bay_water, OR(FEATHER, ROOSTER)) # jesus jump (can always reach bay_water with jesus jumping from every way to enter bay_water, so no one_way)
-            animal_village.connect(bay_water, OR(FEATHER, ROOSTER)) # jesus jump (can always reach bay_water with jesus jumping from every way to enter bay_water, so no one_way)
-            ukuku_prairie.connect(bay_water, OR(FEATHER, ROOSTER), one_way=True) # jesus jump
-            bay_water.connect(d5_entrance, OR(FEATHER, ROOSTER)) # jesus jump into d5 entrance (wall clip), wall clip + jesus jump to get out
-            
+            left_bay_area.connect(bay_water, OR(FEATHER, ROOSTER)) # jesus jump/rooster (can always reach bay_water with jesus jumping from every way to enter bay_water, so no one_way)
+            animal_village.connect(bay_water, OR(FEATHER, ROOSTER)) # jesus jump/rooster (can always reach bay_water with jesus jumping from every way to enter bay_water, so no one_way)
+            ukuku_prairie.connect(bay_water, OR(FEATHER, ROOSTER), one_way=True) # jesus jump/rooster
+            bay_water.connect(d5_entrance, OR(FEATHER, ROOSTER)) # jesus jump/rooster into d5 entrance (wall clip), wall clip + jesus jump to get out
+            prairie_island_seashell.connect(ukuku_prairie, AND(ROOSTER, r.bush)) # jesus rooster from right side, screen transition on top of the water to reach the island
+            bay_madbatter_connector_exit.connect(bay_madbatter_connector_entrance, ROOSTER, one_way=True) # jesus rooster (3 screen) through the underground passage leading to martha's bay mad batter
+
             crow_gold_leaf.connect(castle_courtyard, BOMB) # bird on tree at left side kanalet, place a bomb against the tree and the crow flies off. With well placed second bomb the crow can be killed
             mermaid_statue.connect(animal_village, AND(TRADING_ITEM_SCALE, FEATHER)) # early mermaid statue by buffering on top of the right ledge, then superjumping to the left (horizontal pixel perfect)
             animal_village_bombcave_heartpiece.connect(animal_village_bombcave, PEGASUS_BOOTS) # boots bonk across bottom wall (both at entrance and in item room)
@@ -578,26 +580,20 @@ class World:
             d6_armos_island.connect(ukuku_prairie, OR(FEATHER, ROOSTER)) # jesus jump/rooster (3 screen) from seashell mansion to armos island
             armos_fairy_entrance.connect(d6_armos_island, PEGASUS_BOOTS, one_way=True) # jesus jump from top (fairy bomb cave) to armos island with fast falling 
             d6_connector_right.connect(d6_connector_left, PEGASUS_BOOTS) # boots bonk across bottom wall at water and pits (can do both ways)
-            
+            d6_entrance.connect(ukuku_prairie, ROOSTER, one_way=True) # jesus rooster (2 screen) from d6 entrance bottom ledge to ukuku prairie
+            d6_entrance.connect(armos_fairy_entrance, ROOSTER, one_way=True) # jesus rooster (2 screen) from d6 entrance top ledge to armos fairy entrance
+            armos_fairy_entrance.connect(d6_armos_island, ROOSTER, one_way=True) # jesus rooster from top (fairy bomb cave) to armos island
+            armos_fairy_entrance.connect(raft_exit, ROOSTER) # jesus rooster (2-ish screen) from fairy cave to lower raft connector
+
             obstacle_cave_entrance.connect(obstacle_cave_inside, OR(HOOKSHOT, AND(FEATHER, PEGASUS_BOOTS, OR(SWORD, MAGIC_ROD, BOW)))) # get past crystal rocks by hookshotting into top pushable block, or boots dashing into top wall where the pushable block is to superjump down
             obstacle_cave_entrance.connect(obstacle_cave_inside, AND(PEGASUS_BOOTS, ROOSTER)) # get past crystal rocks pushing the top pushable block, then boots dashing up picking up the rooster before bonking. Pause buffer until rooster is fully picked up then throw it down before bonking into wall
-            d4_entrance.connect(below_right_taltal, OR(FEATHER, ROOSTER), one_way=True) # jesus jump 5 screens to staircase below damp cave
-            lower_right_taltal.connect(below_right_taltal, OR(FEATHER, ROOSTER), one_way=True) # jesus jump to upper ledges, jump off, enter and exit s+q menu to regain pauses, then jesus jump 4 screens to staircase below damp cave
-
-            # jesus rooster section
-            prairie_island_seashell.connect(ukuku_prairie, AND(ROOSTER, r.bush)) # jesus jump from right side, screen transition on top of the water to reach the island
-            bay_madbatter_connector_exit.connect(bay_madbatter_connector_entrance, ROOSTER, one_way=True) # jesus jump (3 screen) through the underground passage leading to martha's bay mad batter
-            self._addEntranceRequirement("prairie_madbatter_connector_entrance", AND(ROOSTER, POWER_BRACELET)) # villa buffer into the top side of the bush, then pick it up
-            d6_entrance.connect(ukuku_prairie, ROOSTER, one_way=True) # jesus jump (2 screen) from d6 entrance bottom ledge to ukuku prairie
-            d6_entrance.connect(armos_fairy_entrance, ROOSTER, one_way=True) # jesus jump (2 screen) from d6 entrance top ledge to armos fairy entrance
-            d6_connector_left.connect(d6_connector_right, ROOSTER) # jesus jump over water <-> left side is jumpable, or villa buffer if it's easier for you
-            armos_fairy_entrance.connect(d6_armos_island, ROOSTER, one_way=True) # jesus jump from top (fairy bomb cave) to armos island
-            armos_fairy_entrance.connect(raft_exit, ROOSTER) # jesus jump (2-ish screen) from fairy cave to lower raft connector
-            self._addEntranceRequirement("heartpiece_swim_cave", ROOSTER)  # jesus jump into the cave entrance after jumping down the ledge, can jesus jump back to the ladder 1 screen below
-            self._addEntranceRequirement("mambo", ROOSTER)  # jesus jump from (unlocked) d4 entrance to mambo's cave entrance
-            outside_raft_house.connect(below_right_taltal, ROOSTER, one_way=True) # jesus jump from the ledge at raft to the staircase 1 screen south
-            self._addEntranceRequirement("multichest_left", ROOSTER) # jesus jump past staircase leading up the mountain 
-            outside_rooster_house.connect(lower_right_taltal, ROOSTER, one_way=True) # jesus jump down to staircase below damp cave
+            d4_entrance.connect(below_right_taltal, OR(FEATHER, ROOSTER), one_way=True) # jesus jump/rooster 5 screens to staircase below damp cave
+            lower_right_taltal.connect(below_right_taltal, OR(FEATHER, ROOSTER), one_way=True) # jesus jump/rooster to upper ledges, jump off, enter and exit s+q menu to regain pauses, then jesus jump 4 screens to staircase below damp cave
+            self._addEntranceRequirement("heartpiece_swim_cave", ROOSTER)  # jesus rooster into the cave entrance after jumping down the ledge, can jesus jump back to the ladder 1 screen below
+            self._addEntranceRequirement("mambo", ROOSTER)  # jesus rooster from d4 entrance to mambo's cave entrance
+            outside_raft_house.connect(below_right_taltal, ROOSTER, one_way=True) # jesus rooster from the ledge at raft to the staircase 1 screen south
+            self._addEntranceRequirement("multichest_left", ROOSTER) # jesus rooster past staircase leading up the mountain 
+            outside_rooster_house.connect(lower_right_taltal, ROOSTER, one_way=True) # jesus rooster down to staircase below damp cave
             
             if options.entranceshuffle in ("default", "simple"): # connector cave from armos d6 area to raft shop may not be randomized to add a flippers path since flippers stop you from jesus jumping
                 below_right_taltal.connect(raft_game, AND(OR(FEATHER, ROOSTER), r.attack_hookshot_powder), one_way=True) # jesus jump from heartpiece water cave, around the island and clip past the diagonal gap in the rock, then jesus jump all the way down the waterfall to the chests (attack req for hardlock flippers+feather scenario)

--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -537,7 +537,7 @@ class World:
             self._addEntranceRequirement("mambo", OR(FEATHER, ROOSTER))  # jesus jump/rooster from d4 entrance to mambo's cave entrance
             outside_raft_house.connect(below_right_taltal, OR(FEATHER, ROOSTER), one_way=True) # jesus jump/rooster from the ledge at raft to the staircase 1 screen south
             d4_entrance.connect(below_right_taltal, ROOSTER, one_way=True) # jesus rooster (4 transitions) to staircase below damp cave
-            lower_right_taltal.connect(below_right_taltal, ROOSTER, one_way=True) # rooster to waterfall ledges, jump off, enter and exit s+q menu to regain pauses, jesus rooster 3 transitions to staircase below damp cave
+            lower_right_taltal.connect(below_right_taltal, ROOSTER, one_way=True) # jump off ledge above d4, jesus rooster 4 transitions to staircase below damp cave
 
             self._addEntranceRequirement("multichest_left", FEATHER) # jesus jump past staircase leading up the mountain 
             outside_rooster_house.connect(lower_right_taltal, FEATHER) # jesus jump (1 or 2 screen depending if angler key is used) to staircase leading up the mountain

--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -536,7 +536,7 @@ class World:
             self._addEntranceRequirement("heartpiece_swim_cave", OR(FEATHER, ROOSTER))  # jesus jump/rooster into the cave entrance after jumping down the ledge, can jesus jump/rooster back to the ladder 1 screen below
             self._addEntranceRequirement("mambo", OR(FEATHER, ROOSTER))  # jesus jump/rooster from d4 entrance to mambo's cave entrance
             outside_raft_house.connect(below_right_taltal, OR(FEATHER, ROOSTER), one_way=True) # jesus jump/rooster from the ledge at raft to the staircase 1 screen south
-            d4_entrance.connect(below_right_taltal, ROOSTER) # jesus rooster (4 transitions) to staircase below damp cave
+            d4_entrance.connect(below_right_taltal, ROOSTER, one_way=True) # jesus rooster (4 transitions) to staircase below damp cave
             lower_right_taltal.connect(below_right_taltal, ROOSTER, one_way=True) # rooster to waterfall ledges, jump off, enter and exit s+q menu to regain pauses, jesus rooster 3 transitions to staircase below damp cave
 
             self._addEntranceRequirement("multichest_left", FEATHER) # jesus jump past staircase leading up the mountain 
@@ -589,7 +589,7 @@ class World:
             
             obstacle_cave_entrance.connect(obstacle_cave_inside, OR(HOOKSHOT, AND(FEATHER, PEGASUS_BOOTS, OR(SWORD, MAGIC_ROD, BOW)))) # get past crystal rocks by hookshotting into top pushable block, or boots dashing into top wall where the pushable block is to superjump down
             obstacle_cave_entrance.connect(obstacle_cave_inside, AND(PEGASUS_BOOTS, ROOSTER)) # get past crystal rocks pushing the top pushable block, then boots dashing up picking up the rooster before bonking. Pause buffer until rooster is fully picked up then throw it down before bonking into wall
-            d4_entrance.connect(below_right_taltal, FEATHER) # jesus jump 5 screens to staircase below damp cave
+            d4_entrance.connect(below_right_taltal, FEATHER, one_way=true) # jesus jump 5 screens to staircase below damp cave
             lower_right_taltal.connect(below_right_taltal, FEATHER, one_way=True) # jesus jump to waterfall ledges, jump off, enter and exit s+q menu to regain pauses, then jesus jump 4 screens to staircase below damp cave
             
             if options.entranceshuffle in ("default", "simple"): # connector cave from armos d6 area to raft shop may not be randomized to add a flippers path since flippers stop you from jesus jumping


### PR DESCRIPTION
Adds jesus rooster as an option in any spot not already accounting rooster over water (the multi-screen jesus jump spots), in hell logic only.

This fixes issue #84. If you haven't already, read through the issue.