### PR TITLE
Fixed plando pool

### DIFF
--- a/itempool.py
+++ b/itempool.py
@@ -68,10 +68,12 @@ DEFAULT_ITEM_POOL = {
 
 
 class ItemPool:
-    def __init__(self, logic, settings, rnd):
+    def __init__(self, logic, settings, rnd, plando):
         self.__pool = {}
         self.__setup(logic, settings)
-        self.__randomizeRupees(settings, rnd)
+
+        if not plando:
+            self.__randomizeRupees(settings, rnd)
 
     def add(self, item, count=1):
         self.__pool[item] = self.__pool.get(item, 0) + count

--- a/randomizer.py
+++ b/randomizer.py
@@ -117,10 +117,10 @@ class Randomizer:
         item_pool = {}
         # Build the item pool to see which items we can randomize.
         if settings.multiworld is None:
-            item_pool = itempool.ItemPool(self.__logic, settings, self.rnd).toDict()
+            item_pool = itempool.ItemPool(self.__logic, settings, self.rnd, self.plan != None).toDict()
         else:
             for world in range(settings.multiworld):
-                world_item_pool = itempool.ItemPool(self.__logic.worlds[world], settings.multiworld_settings[world], self.rnd).toDict()
+                world_item_pool = itempool.ItemPool(self.__logic.worlds[world], settings.multiworld_settings[world], self.rnd, self.plan != None).toDict()
                 for item, count in world_item_pool.items():
                     item_pool["%s_W%d" % (item, world)] = count
 

--- a/worldSetup.py
+++ b/worldSetup.py
@@ -85,6 +85,8 @@ class WorldSetup:
         return [x for x in entrancePool if log.world.overworld_entrance[x].location not in log.location_list]
 
     def pickEntrances(self, settings, rnd):
+        if settings.overworld == "random":
+            return
         if settings.overworld == "dungeondive":
             self.entrance_mapping = {"d%d" % (n): "d%d" % (n) for n in range(9)}
         if settings.randomstartlocation and settings.entranceshuffle == "none":


### PR DESCRIPTION
This disables item pool randomization when a plan has been loaded, which should make it easier to make a functional plan file when planning a large number of checks.

I thought about something more elaborate that would preserve explicitly planned rupees, but it didn't seem like it was worth the effort or complexity. I'm open to suggestions, though.