### PR TITLE
2023-05 logic tweaks

### DIFF
--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -224,7 +224,8 @@ class World:
         self._addEntrance("richard_house", ukuku_prairie, richard_house, None)
         self._addEntrance("richard_maze", richard_maze, richard_cave, None)
         slime_key_area = Location().connect(richard_maze, OR(SWORD, AND(MAGIC_POWDER, MAX_POWDER_UPGRADE), MAGIC_ROD, POWER_BRACELET, BOOMERANG))
-        Location().add(OwlStatue(0x0C6)).connect(slime_key_area, options.owlstatues in ('both', 'overworld'))
+        if options.owlstatues == "both" or options.owlstatues == "overworld":
+            Location().add(OwlStatue(0x0C6)).connect(slime_key_area, None)
         Location().add(SlimeKey()).connect(slime_key_area, SHOVEL)
 
         next_to_castle = Location()

--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -226,9 +226,9 @@ class World:
         richard_maze = Location()
         self._addEntrance("richard_house", ukuku_prairie, richard_house, None)
         self._addEntrance("richard_maze", richard_maze, richard_cave, None)
-        if options.owlstatues == "both" or options.owlstatues == "overworld":
-            Location().add(OwlStatue(0x0C6)).connect(richard_maze, r.bush)
-        Location().add(SlimeKey()).connect(richard_maze, AND(OR(SWORD, AND(MAGIC_POWDER, MAX_POWDER_UPGRADE), MAGIC_ROD, POWER_BRACELET, BOOMERANG), SHOVEL))
+        slime_key_area = Location().connect(richard_maze, OR(SWORD, AND(MAGIC_POWDER, MAX_POWDER_UPGRADE), MAGIC_ROD, POWER_BRACELET, BOOMERANG))
+        Location().add(OwlStatue(0x0C6)).connect(slime_key_area, options.owlstatues in ('both', 'overworld'))
+        Location().add(SlimeKey()).connect(slime_key_area, SHOVEL)
 
         next_to_castle = Location()
         if options.tradequest:

--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -357,8 +357,9 @@ class World:
         lower_right_taltal.connect(d4_entrance, AND(ANGLER_KEY, "ANGLER_KEYHOLE"), one_way=True)
         self._addEntrance("d4", d4_entrance, None, ANGLER_KEY)
         self._addEntranceRequirementExit("d4", FLIPPERS) # if exiting, you can leave with flippers without opening the dungeon
+        outside_mambo = Location().connect(d4_entrance, FLIPPERS)
         mambo = Location().connect(Location().add(Song(0x2FD)), AND(OCARINA, FLIPPERS))  # Manbo's Mambo
-        self._addEntrance("mambo", d4_entrance, mambo, FLIPPERS) 
+        self._addEntrance("mambo", outside_mambo, mambo, None) 
 
         # Raft game.
         raft_house = Location()
@@ -531,7 +532,7 @@ class World:
             lower_right_taltal.connect(hibiscus_item, AND(TRADING_ITEM_PINEAPPLE, BOMB), one_way=True) # bomb trigger papahl from below ledge, requires pineapple
             
             self._addEntranceRequirement("heartpiece_swim_cave", FEATHER)  # jesus jump into the cave entrance after jumping down the ledge, can jesus jump back to the ladder 1 screen below
-            self._addEntranceRequirement("mambo", FEATHER)  # jesus jump from (unlocked) d4 entrance to mambo's cave entrance
+            outside_mambo.connect(d4_entrance, FEATHER)  # jesus jump from (unlocked) d4 entrance to mambo's cave entrance
             outside_raft_house.connect(below_right_taltal, FEATHER, one_way=True) # jesus jump from the ledge at raft to the staircase 1 screen south
 
             self._addEntranceRequirement("multichest_left", FEATHER) # jesus jump past staircase leading up the mountain 
@@ -593,7 +594,7 @@ class World:
             d4_entrance.connect(below_right_taltal, OR(FEATHER, ROOSTER), one_way=True) # jesus jump/rooster 5 screens to staircase below damp cave
             lower_right_taltal.connect(below_right_taltal, OR(FEATHER, ROOSTER), one_way=True) # jesus jump/rooster to upper ledges, jump off, enter and exit s+q menu to regain pauses, then jesus jump 4 screens to staircase below damp cave
             self._addEntranceRequirement("heartpiece_swim_cave", ROOSTER)  # jesus rooster into the cave entrance after jumping down the ledge, can jesus jump back to the ladder 1 screen below
-            self._addEntranceRequirement("mambo", ROOSTER)  # jesus rooster from d4 entrance to mambo's cave entrance
+            outside_mambo.connect(below_right_taltal, OR(FEATHER, ROOSTER))  # jesus jump/rooster to mambo's cave entrance
             outside_raft_house.connect(below_right_taltal, ROOSTER, one_way=True) # jesus rooster from the ledge at raft to the staircase 1 screen south
             self._addEntranceRequirement("multichest_left", ROOSTER) # jesus rooster past staircase leading up the mountain 
             outside_rooster_house.connect(lower_right_taltal, ROOSTER, one_way=True) # jesus rooster down to staircase below damp cave

--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -210,10 +210,7 @@ class World:
         bay_water.connect(ukuku_prairie, FLIPPERS)
         bay_water.connect(left_bay_area, FLIPPERS)
         fisher_under_bridge = Location().add(TradeSequenceItem(0x2F5, TRADING_ITEM_NECKLACE))
-        if options.logic == "casual":
-            fisher_under_bridge.connect(bay_water, AND(TRADING_ITEM_FISHING_HOOK, FEATHER, FLIPPERS))
-        else:
-            fisher_under_bridge.connect(bay_water, AND(TRADING_ITEM_FISHING_HOOK, OR(FEATHER, SWORD, BOW), FLIPPERS)) # just swing/shoot at fisher, trivially easy
+        fisher_under_bridge.connect(bay_water, AND(TRADING_ITEM_FISHING_HOOK, FEATHER, FLIPPERS))
         bay_water.connect(Location().add(TradeSequenceItem(0x0C9, TRADING_ITEM_SCALE)), AND(TRADING_ITEM_NECKLACE, FLIPPERS))
         d5_entrance = Location().connect(bay_water, FLIPPERS)
         self._addEntrance("d5", d5_entrance, None, None)

--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -513,7 +513,8 @@ class World:
             bay_madbatter_connector_exit.connect(bay_madbatter_connector_entrance, FEATHER, one_way=True) # jesus jump (3 screen) through the underground passage leading to martha's bay mad batter
             self._addEntranceRequirement("prairie_madbatter_connector_entrance", AND(OR(FEATHER, ROOSTER), POWER_BRACELET)) # villa buffer into the top side of the bush, then pick it up
             
-            ukuku_prairie.connect(richard_maze, OR(SWORD, AND(MAGIC_POWDER, MAX_POWDER_UPGRADE), MAGIC_ROD, BOOMERANG, BOMB)) # break bushes on north side of the maze, and 1 pit buffer into the maze. Do the same in one of the two northern screens of the maze to escape
+            ukuku_prairie.connect(richard_maze, OR(SWORD, AND(MAGIC_POWDER, MAX_POWDER_UPGRADE), MAGIC_ROD, BOOMERANG, BOMB), one_way=True) # break bushes on north side of the maze, and 1 pit buffer into the maze
+            richard_maze.connect(ukuku_prairie, OR(SWORD, MAGIC_POWDER, MAGIC_ROD, BOOMERANG, BOMB), one_way=True) # do the same as above (but without powder capacity) in one of the two northern screens of the maze to escape
             fisher_under_bridge.connect(bay_water, AND(BOMB, FLIPPERS)) # up-most left wall is a pit: bomb trigger with it 
             animal_village.connect(ukuku_prairie, FEATHER) # jesus jump
             below_right_taltal.connect(next_to_castle, FEATHER) # jesus jump (north of kanalet castle phonebooth)


### PR DESCRIPTION
This has two logic tweaks:
- Allow jesus jumping to Manbo's cave without the angler key in hell logic. I did this by splitting the watery area to the left of the D4 entrance into its own location and connecting that to the shore. Note that I removed Manbo's entrance requirements because it seems redundant now, but please double check me there.
- Make the requirements for Richard's owl the same as the slime key dig (minus the shovel). The powder upgrade wasn't originally required for the owl, but it was for the dig.