### PR TITLE
Solve assertion errors when certain modes are combined, and small adjustment to item pool casual & no_dungeons

### DIFF
--- a/itempool.py
+++ b/itempool.py
@@ -112,15 +112,6 @@ class ItemPool:
         elif settings.owlstatues == 'overworld':
             self.add(RUPEES_20, 9)
 
-        if settings.bowwow == 'always':
-            # Bowwow mode takes a sword from the pool to give as bowwow. So we need to fix that.
-            self.add(SWORD)
-            self.remove(BOWWOW)
-        elif settings.bowwow == 'swordless':
-            # Bowwow mode takes a sword from the pool to give as bowwow, we need to remove all swords and Bowwow except for 1
-            self.add(RUPEES_20, self.get(BOWWOW) + self.get(SWORD) - 1)
-            self.remove(SWORD, self.get(SWORD) - 1)
-            self.remove(BOWWOW, self.get(BOWWOW))
         if settings.hpmode == 'inverted':
             self.add(BAD_HEART_CONTAINER, self.get(HEART_CONTAINER))
             self.remove(HEART_CONTAINER, self.get(HEART_CONTAINER))
@@ -132,6 +123,7 @@ class ItemPool:
             self.remove(HEART_CONTAINER, self.get(HEART_CONTAINER))
 
         if settings.itempool == 'casual':
+            self.add(SWORD)
             self.add(FLIPPERS)
             self.add(FEATHER)
             self.add(HOOKSHOT)
@@ -144,7 +136,7 @@ class ItemPool:
             self.add(POWER_BRACELET)
             self.add(SHOVEL)
             self.add(RUPEES_200, 2)
-            self.removeRupees(13)
+            self.removeRupees(14)
 
             for n in range(9):
                 self.remove("MAP%d" % (n + 1))
@@ -236,6 +228,16 @@ class ItemPool:
             self.remove(RUPEES_100, 3)
             self.add(RUPEES_500, 3)
 
+        if settings.bowwow == 'always':
+            # Bowwow mode takes a sword from the pool to give as bowwow. So we need to fix that.
+            self.add(SWORD)
+            self.remove(BOWWOW)
+        elif settings.bowwow == 'swordless':
+            # Bowwow mode takes a sword from the pool to give as bowwow, we need to remove all swords and Bowwow except for 1
+            self.add(RUPEES_20, self.get(BOWWOW) + self.get(SWORD) - 1)
+            self.remove(SWORD, self.get(SWORD) - 1)
+            self.remove(BOWWOW, self.get(BOWWOW))
+            
         if settings.goal == "seashells":
             for n in range(8):
                 self.remove("INSTRUMENT%d" % (n + 1))

--- a/itempool.py
+++ b/itempool.py
@@ -154,9 +154,9 @@ class ItemPool:
         elif settings.itempool == 'pain':
             self.add(BAD_HEART_CONTAINER, 12)
             self.remove(BLUE_TUNIC)
-            self.remove(MEDICINE, 2)
+            self.removeRupees(7-self.get(MEDICINE))
+            self.remove(MEDICINE, self.get(MEDICINE))
             self.remove(HEART_PIECE, 4)
-            self.removeRupees(5)
         elif settings.itempool == 'keyup':
             for n in range(9):
                 self.remove("MAP%d" % (n + 1))
@@ -177,11 +177,6 @@ class ItemPool:
                         self.remove(item_name, self.__pool[item_name])
                     self.add(item_name, amount)
 
-        if settings.goal == "seashells":
-            for n in range(8):
-                self.remove("INSTRUMENT%d" % (n + 1))
-            self.add(SEASHELL, 8)
-
         if settings.overworld == "dungeondive":
             self.remove(SWORD)
             self.remove(MAX_ARROWS_UPGRADE)
@@ -198,8 +193,8 @@ class ItemPool:
             self.remove(SONG3)
             self.remove(HEART_PIECE, 8)
             self.remove(RUPEES_50, 9)
-            self.remove(RUPEES_20, 2)
-            self.remove(MEDICINE, 3)
+            self.removeRupees(5-self.get(MEDICINE))
+            self.remove(MEDICINE, self.get(MEDICINE))
             self.remove(MESSAGE)
             self.remove(BOWWOW)
             self.remove(ROOSTER)
@@ -233,14 +228,20 @@ class ItemPool:
             self.remove(BLUE_TUNIC)
             self.remove(RED_TUNIC)
             self.remove(SEASHELL, 2)
-            self.remove(RUPEES_20, 6)
-            self.remove(RUPEES_50, 17)
-            self.remove(MEDICINE, 3)
+            self.removeRupees(26-self.get(MEDICINE))
+            self.remove(MEDICINE, self.get(MEDICINE))
             self.remove(GEL, 4)
             self.remove(MESSAGE, 1)
             self.remove(BOMB, 1)
             self.remove(RUPEES_100, 3)
             self.add(RUPEES_500, 3)
+
+        if settings.goal == "seashells":
+            for n in range(8):
+                self.remove("INSTRUMENT%d" % (n + 1))
+            self.add(SEASHELL, 8)
+            if self.get(SEASHELL) < 20:
+                raise RuntimeError("Not enough seashells (" + str(self.get(SEASHELL)) + ") available in itempool")
 
         # In multiworld, put a bit more rupees in the seed, this helps with generation (2nd shop item)
         #   As we cheat and can place rupees for the wrong player.
@@ -261,6 +262,8 @@ class ItemPool:
                 rupee_item.append(k)
                 rupee_item_count.append(v)
         rupee_chests = sum(v for k, v in self.__pool.items() if k.startswith("RUPEES_"))
+        if rupee_chests // 5 > sum(rupee_item_count):
+            rupee_chests = 5*sum(rupee_item_count)
         for n in range(rupee_chests // 5):
             new_item = rnd.choices((BOMB, SINGLE_ARROW, ARROWS_10, MAGIC_POWDER, MEDICINE), (10, 5, 10, 10, 1))[0]
             while True:

--- a/itempool.py
+++ b/itempool.py
@@ -91,7 +91,7 @@ class ItemPool:
             self.removeRupee()
 
     def removeRupee(self):
-        for item in (RUPEES_20, RUPEES_50, RUPEES_200, RUPEES_500):
+        for item in (RUPEES_20, RUPEES_50, RUPEES_100, RUPEES_200, RUPEES_500):
             if self.get(item) > 0:
                 self.remove(item)
                 return
@@ -217,15 +217,17 @@ class ItemPool:
             for n in range(9):
                 for item_name in {KEY, NIGHTMARE_KEY, MAP, COMPASS, STONE_BEAK}:
                     self.remove(f"{item_name}{n+1}", self.get(f"{item_name}{n+1}"))
-            self.remove(BLUE_TUNIC)
+            if self.get(BLUE_TUNIC) > 0:
+                self.remove(BLUE_TUNIC)
+            else:
+                self.removeRupee()
             self.remove(RED_TUNIC)
-            self.remove(SEASHELL, 2)
-            self.removeRupees(26-self.get(MEDICINE))
+            self.remove(SEASHELL, 3)
+            self.removeRupees(28-self.get(MEDICINE))
             self.remove(MEDICINE, self.get(MEDICINE))
             self.remove(GEL, 4)
             self.remove(MESSAGE, 1)
             self.remove(BOMB, 1)
-            self.remove(RUPEES_100, 3)
             self.add(RUPEES_500, 3)
 
         if settings.bowwow == 'always':

--- a/itempool.py
+++ b/itempool.py
@@ -223,11 +223,10 @@ class ItemPool:
                 self.removeRupee()
             self.remove(RED_TUNIC)
             self.remove(SEASHELL, 3)
-            self.removeRupees(28-self.get(MEDICINE))
+            self.removeRupees(29-self.get(MEDICINE))
             self.remove(MEDICINE, self.get(MEDICINE))
             self.remove(GEL, 4)
             self.remove(MESSAGE, 1)
-            self.remove(BOMB, 1)
             self.add(RUPEES_500, 3)
 
         if settings.bowwow == 'always':

--- a/settings.py
+++ b/settings.py
@@ -315,6 +315,8 @@ If random start location and/or dungeon shuffle is enabled, then these will be s
         if self.goal == "maze":
             req("overworld", "normal", "Maze goal does not work with dungeondive")
             req("accessibility", "all", "Maze goal needs 'all' accessibility")
+        if self.itempool == "pain":
+            req("heartpiece", True, "Path of pain removes heart pieces")
         if self.overworld == "dungeondive":
             dis("owlstatues", "overworld", "", "Dungeon dive does not work with owl statues in overworld")
             dis("owlstatues", "both", "dungeon", "Dungeon dive does not work with owl statues in overworld")

--- a/settings.py
+++ b/settings.py
@@ -316,9 +316,13 @@ If random start location and/or dungeon shuffle is enabled, then these will be s
             req("overworld", "normal", "Maze goal does not work with dungeondive")
             req("accessibility", "all", "Maze goal needs 'all' accessibility")
         if self.overworld == "dungeondive":
-            dis("goal", "seashells", "8", "Dungeon dive does not work with seashell goal")
+            dis("owlstatues", "overworld", "", "Dungeon dive does not work with owl statues in overworld")
+            dis("owlstatues", "both", "dungeon", "Dungeon dive does not work with owl statues in overworld")
+            if (self.itempool == "pain") & (self.owlstatues == ""):
+                req("accessibility", "goal", "Dungeon dive does not leave enough rupees in itempool for all accessibility")
         if self.overworld == "nodungeons":
-            dis("goal", "seashells", "8", "No dungeons does not work with seashell goal")
+            dis("owlstatues", "dungeon", "", "No dungeons does not work with owl statues in dungeons")
+            dis("owlstatues", "both", "overworld", "No dungeons does not work with owl statues in dungeons")
         if self.overworld == "random":
             self.goal = "4"  # Force 4 dungeon goal for random overworld right now.
 


### PR DESCRIPTION
Solve assertion errors caused by certain combinations of mode, and more explicit error handling in itempool for users to see why seed generation fails. Also catch owl statue randomization via settings when chosen option has owl statues that do not exist (dungeon dive or no_dungeons). 

Also, add a sword to the casual item pool and remove an extra seashell in no_dungeons