### PR TITLE
Website: Disable non-aesthetic options when loading race seed permalink

### DIFF
--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -176,11 +176,12 @@ function buildUI(filter_function) {
         if (filter_function && !filter_function(s)) continue;
         if (last_cat != s.category) {
             if (last_cat != "") html += `</div>`;
-            html += `<div class="row"><div class="col-sm-12"><h1>${s.category}</h1></div>`
+            html += `<div class="row category-${s.category.replaceAll(' ','_')}">`
+            html += `<div class="col-sm-12"><h1>${s.category}</h1></div>`
             last_cat = s.category;
         }
         html += `<div class="col-sm-12 col-md-6 col-lg-4 inputcontainerparent">`;
-        html += `<div class="inputcontainer tooltip bottom" aria-label="${s.description.trim()}">`;
+        html += `<div class="inputcontainer tooltip bottom option-${s.key}" aria-label="${s.description.trim()}">`;
         html += `<label for='${s.key}'>${s.label}:</label>`;
         var opts = s.options
         if (typeof(s.default) == 'boolean') {
@@ -217,6 +218,39 @@ function buildUI(filter_function) {
             };
         }
     }
+
+    // disable non-aesthetic options when loading race seed
+    if (ID('race').value == 'true' && ID('seed').value) {
+        for(var s of options) { 
+            if (s.aesthetic) continue;
+            var input = document.querySelector(`.option-${s.key} input, .option-${s.key} select`);
+            if(input)
+                input.setAttribute('disabled', true);
+        }
+
+        // indicate fully disabled categories
+        var categories = []
+        for(var s of options) {
+            if (!categories.includes(s.category))
+                categories.push(s.category);
+        }
+        for(var s of options) {
+            if (!s.aesthetic) continue;
+            if (categories.includes(s.category))
+                categories.splice(categories.indexOf(s.category), 1);
+        }
+        for(var c of categories) {
+            var category = document.querySelector(`.category-${c.replaceAll(' ', '_')}`);
+            if (category) {
+                ID('settings').append(category) // send to the bottom of settings so unlocked categories rise to top
+                category.style.opacity = 0.8;
+            }
+            var h1 = document.querySelector(`.category-${c.replaceAll(' ', '_')} h1`);
+            if (h1)
+                h1.innerHTML = '&#128274; ' + h1.innerHTML; // prepend 🔒 emoji
+        }
+    }
+
     updateGfxModImage();
     updateSettingsString();
     updateForm();


### PR DESCRIPTION
When people send around race seeds it can be a little confusing that it's fully editable. Ideally, people should be editing aesthetic options as they like and leaving the other options alone.

When reading the short string, if the race flag is on and a seed is provided, this disables the input/select element for any option not marked `aesthetic`.
In addition, any category that only has disabled options is given an indicator and sent to the bottom for better clarity.

The options are infinite for how to indicate to the user which options should be left alone, I figured I'd just take a shot at one. If you'd like to see it done a different way I'm happy to play around with it however you like. I figured I'd try to take some work off your plate instead of just making a request. I really appreciate the work so far :)

![Screenshot 2023-09-28 at 14-59-12 Screenshot](https://github.com/daid/LADXR/assets/26460970/f37b245d-7e4b-4414-9efe-f9abd5910d57)