### PR TITLE
Website: remove aesthetic options from seed share link

### DIFF
--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -6,15 +6,14 @@ var spoilerContent;
 function ID(s) { return document.getElementById(s); }
 
 function getShareLink(data) {
-    var result = document.location;
-    if (ID("seed").value == "") {
+    var seedProvided = !ID("seed").value == "";
+    if(!seedProvided)
         ID("seed").value = data.seed;
-        updateSettingsString();
-        result = document.location.toString();
+    var hash = '#' + generateSettingsString(function(s) { return !s.aesthetic; });
+    if(!seedProvided)
         ID("seed").value = "";
-        updateSettingsString();
-    }
-    return result
+    var l = document.location;
+    return l.origin + l.pathname + l.search + hash;
 }
 
 async function seedComplete(data) {
@@ -109,9 +108,14 @@ function updateGfxModImage() {
     }
 }
 
-function updateSettingsString() {
+function updateSettingsString(filter_function) {
+    document.location.hash = generateSettingsString(filter_function);
+}
+
+function generateSettingsString(filter_function) {
     var sss = "";
     for(var s of options) {
+        if (filter_function && !filter_function(s)) continue;
         var e = ID(s.key);
         if (!e || s.short_key === undefined) continue;
         if (typeof(s.default) == 'boolean') {
@@ -124,7 +128,6 @@ function updateSettingsString() {
             sss += s.short_key + e.value + ">";
         }
     }
-    document.location.hash = sss;
     return sss;
 }
 


### PR DESCRIPTION
When people pass around seed permalinks, the aesthetic options are almost always unwanted.

This omits any setting marked `aesthetic` from the share link's short string.