### PR TITLE
Website: Remember valid ROM

### DIFF
--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -268,7 +268,11 @@ function checkStoredRom()
             }
         }
     }
-    catch(e){}
+    catch(e)
+    {
+        console.log("Error while loading stored ROM:")
+        console.log(e);
+    }
 }
 
 function updateForm()
@@ -320,7 +324,11 @@ function updateForm()
                     for(var b of a) { s += String.fromCharCode(b); }
                     localStorage.setItem("ladx_rom", btoa(s));
                 }
-                catch(e){}
+                catch(e)
+                {
+                    console.log("Error while storing ROM:")
+                    console.log(e);
+                }
             }
         });
     }

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -2,6 +2,8 @@
 
 var worker;
 var spoilerContent;
+var romArray;
+var storedRomArray;
 
 function ID(s) { return document.getElementById(s); }
 
@@ -14,6 +16,10 @@ function getShareLink(data) {
         ID("seed").value = "";
     var l = document.location;
     return l.origin + l.pathname + l.search + hash;
+}
+
+function getRomArray() {
+    return romArray;
 }
 
 async function seedComplete(data) {
@@ -229,15 +235,46 @@ function buildUI(filter_function) {
     }
     updateGfxModImage();
     updateSettingsString();
-    updateForm();
+    checkStoredRom();
+    if (!storedRomArray) updateForm();
 
     ID("rom").onchange = updateForm
 
     ID("submitbutton").onclick = startRomGeneration;
 }
 
+function checkStoredRom()
+{
+    try
+    {
+        var storedRom = localStorage.getItem("ladx_rom");
+        if (storedRom)
+        {
+            var bin = atob(storedRom);
+            var array = new Uint8Array(bin.length);
+            for (var k = 0; k < bin.length; k++)
+            {
+                array[k] = bin.charCodeAt(k);
+            }
+            if (getRomChecksum(array) == 89122269)
+            {
+                romArray = array;
+                storedRomArray = array;
+                setValidRom(true, "ROM has been loaded");
+            }
+            else
+            {
+                localStorage.removeItem("ladx_rom");
+            }
+        }
+    }
+    catch(e){}
+}
+
 function updateForm()
 {
+    romArray = storedRomArray;
+
     var rom = ID("rom");
 
     if (rom.files.length < 1)
@@ -256,8 +293,7 @@ function updateForm()
     {
         rom.files[0].arrayBuffer().then(function(buffer) {
             var a = new Uint8Array(buffer);
-            var checksum = 0;
-            for(var b of a) { checksum += b; }
+            var checksum = getRomChecksum(a);
             console.log("Checksum: " + rom.files[0].name + ": " + checksum);
             if (checksum != 89122269)
             {
@@ -276,7 +312,15 @@ function updateForm()
             }
             else
             {
+                romArray = a;
                 setValidRom(true);
+                try
+                {
+                    var s = "";
+                    for(var b of a) { s += String.fromCharCode(b); }
+                    localStorage.setItem("ladx_rom", btoa(s));
+                }
+                catch(e){}
             }
         });
     }
@@ -284,7 +328,7 @@ function updateForm()
 
 function setValidRom(valid, msg)
 {
-    ID("submitbutton").disabled = !valid;
+    ID("submitbutton").disabled = !valid && !storedRomArray;
     if (valid)
         ID("romlabel").classList.remove("selectromwarning");
     else
@@ -295,13 +339,19 @@ function setValidRom(valid, msg)
         ID("romlabel").innerHTML = "Select input ROM";
 }
 
+function getRomChecksum(array)
+{
+    var checksum = 0;
+    for(var b of array) { checksum += b; }
+    return checksum;
+}
+
 async function startRomGeneration()
 {
     ID("generatingdialog").checked = true;
     randomGenerationString();
-    var buffer = new Uint8Array(await document.getElementById("rom").files[0].arrayBuffer());
     var args = ["--short", updateSettingsString()];
-    var data = {"input.gbc": buffer, "args": args, "id": 0};
+    var data = {"input.gbc": romArray, "args": args, "id": 0};
     var e = ID("spoilerformat");
     if (e && e.value != 'none') {
         args.push("--spoilerformat");

--- a/www/multiworld.html
+++ b/www/multiworld.html
@@ -105,7 +105,7 @@ async function startRomGeneration()
 {
     ID("generatingdialog").checked = true;
     //randomGenerationString();
-    var buffer = new Uint8Array(await document.getElementById("rom").files[0].arrayBuffer());
+    var buffer = getRomArray();
     var args = ["--short", updateSettingsString()];
     var e = ID("spoilerformat");
     if (e && e.value != 'none') {

--- a/www/mystery.html
+++ b/www/mystery.html
@@ -255,7 +255,7 @@ async function startRomGeneration()
 {
     ID("generatingdialog").checked = true;
     randomGenerationString();
-    var buffer = new Uint8Array(await document.getElementById("rom").files[0].arrayBuffer());
+    var buffer = getRomArray();
     if (ID("randomsettings").style.display != "none")
         randomsettings = randomizeSettings();
     var args = ["--short", updateSettingsString() + randomsettings];

--- a/www/plando.html
+++ b/www/plando.html
@@ -83,7 +83,7 @@ async function startRomGeneration()
 {
     ID("generatingdialog").checked = true;
     randomGenerationString();
-    var buffer = new Uint8Array(await document.getElementById("rom").files[0].arrayBuffer());
+    var buffer = getRomArray();
     var args = ["--short", ID('settingsString').value];
     var data = {"input.gbc": buffer, "args": args, "id": 0};
     var e = ID("spoilerformat");


### PR DESCRIPTION
When a valid ROM is selected in any of the 4 seed generators, it's stored in the browser so it doesn't have to be selected by the user the next time the site is loaded.

The file is stored as a Base64-encoded string in local storage. It can be accessed from all HTML files under the same base URL.
I made it so you can still select a different ROM file even after one has already been loaded and verified from local storage, just because that was also possible before this change (could be useful for checking whether a given ROM file is valid, or for replacing an invalid stored file that managed to sneak past the checksum test). In that case, even if you load an invalid file you can still generate a seed using the stored ROM without having to reload the site to clear the selected file.