### PR TITLE
RandomItemPlacer places dungeon keys first

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -125,7 +125,7 @@ def generateRom(args, settings, seed, logic, *, rnd=None, multiworld=None):
     patches.core.fixWrongWarp(rom)
     patches.core.alwaysAllowSecretBook(rom)
     patches.core.injectMainLoop(rom)
-    if settings.dungeon_items in ('localnightmarekey', 'keysanity', 'smallkeys'):
+    if settings.dungeon_items in ('localnightmarekey', 'keysanity', 'smallkeys', 'nightmarekeys'):
         patches.inventory.advancedInventorySubscreen(rom)
     patches.inventory.moreSlots(rom)
     if settings.witch:

--- a/locations/itemInfo.py
+++ b/locations/itemInfo.py
@@ -24,26 +24,27 @@ class ItemInfo:
         return self.OPTIONS
 
     def configure(self, options):
-        if options.dungeon_items in {'localkeys', 'localnightmarekey', 'keysanity', 'smallkeys'}:
+        if options.dungeon_items in {'localkeys', 'localnightmarekey', 'keysanity', 'smallkeys', 'nightmarekeys'}:
             # Add items that can be anywhere due to dungeon items setting
             self.OPTIONS = self.OPTIONS.copy()
             for n in range(10):
-                if options.dungeon_items != 'smallkeys':
+                if options.dungeon_items not in {'smallkeys', 'nightmarekeys'}:
                     self.OPTIONS += ["MAP%d" % (n), "COMPASS%d" % (n), "STONE_BEAK%d" % (n)]
                 if options.dungeon_items in {'localnightmarekey', 'keysanity', 'smallkeys'}:
                     self.OPTIONS += ["KEY%d" % (n)]
-                if options.dungeon_items == 'keysanity':
+                if options.dungeon_items in {'keysanity', 'nightmarekeys'}:
                     self.OPTIONS += ["NIGHTMARE_KEY%d" % (n)]
 
-        if self._location.dungeon is not None and options.dungeon_items in {'', 'localkeys', 'localnightmarekey', 'keysy', 'smallkeys'}:
+        if self._location.dungeon is not None and options.dungeon_items in {'', 'localkeys', 'localnightmarekey', 'keysy', 'smallkeys', 'nightmarekeys'}:
             # Add items specific to this dungeon
             self.OPTIONS = self.OPTIONS.copy()
             d = self._location.dungeon
-            if options.dungeon_items in {'', 'keysy', 'smallkeys'}:
+            if options.dungeon_items in {'', 'keysy', 'smallkeys', 'nightmarekeys'}:
                 self.OPTIONS += ["MAP%d" % (d), "COMPASS%d" % (d), "STONE_BEAK%d" % (d)]
-            if options.dungeon_items in {'', 'localkeys'}:
+            if options.dungeon_items in {'', 'localkeys', 'nightmarekeys'}:
                 self.OPTIONS += ["KEY%d" % (d)]
-            self.OPTIONS += ["NIGHTMARE_KEY%d" % (d)]
+            if options.dungeon_items != 'nightmarekeys':
+                self.OPTIONS += ["NIGHTMARE_KEY%d" % (d)]
 
     def read(self, rom):
         raise NotImplementedError()

--- a/logic/__init__.py
+++ b/logic/__init__.py
@@ -291,14 +291,14 @@ class MultiworldItemInfoWrapper:
     # Return true if the item is allowed to be placed in any world, or false if it is
     # world specific for this check.
     def canMultiworld(self, option):
-        if self.dungeon_items in {'', 'smallkeys'}:
+        if self.dungeon_items in {'', 'smallkeys', 'nightmarekeys'}:
             if option.startswith("MAP"):
                 return False
             if option.startswith("COMPASS"):
                 return False
             if option.startswith("STONE_BEAK"):
                 return False
-        if self.dungeon_items in {'', 'localkeys'}:
+        if self.dungeon_items in {'', 'localkeys', 'nightmarekeys'}:
             if option.startswith("KEY"):
                 return False
         if self.dungeon_items in {'', 'localkeys', 'localnightmarekey', 'smallkeys'}:

--- a/randomizer.py
+++ b/randomizer.py
@@ -64,7 +64,7 @@ class Randomizer:
         elif settings.forwardfactor > 0.0 or settings.overworld in {'dungeonchain'}:
             item_placer = ForwardItemPlacer(self.__logic, settings.forwardfactor, settings.accessibility)
         else:
-            item_placer = RandomItemPlacer(self.__logic, settings.dungeon_items, settings.accessibility)
+            item_placer = RandomItemPlacer(self.__logic, settings.dungeon_items, settings.owlstatues, settings.accessibility)
         for item, count in self.readItemPool(settings, item_placer).items():
             if count > 0:
                 item_placer.addItem(item, count)
@@ -229,9 +229,10 @@ class ItemPlacer:
 
 
 class RandomItemPlacer(ItemPlacer):
-    def __init__(self, logic: logic.Logic, dungeon_item_setting: str, accessibility: str) -> None:
+    def __init__(self, logic: logic.Logic, dungeon_item_setting: str, owl_statue_setting: str, accessibility: str) -> None:
         super().__init__(logic, accessibility)
         self.dungeon_item_setting = dungeon_item_setting
+        self.owl_statue_setting = owl_statue_setting
 
     def run(self, rnd: random.Random) -> None:
         assert sum(self._item_pool.values()) == len(self._spots), "%d != %d" % (sum(self._item_pool.values()), len(self._spots))
@@ -239,6 +240,8 @@ class RandomItemPlacer(ItemPlacer):
 
         # Place keys that are restricted to their dungeon first to avoid running out of valid spots
         dungeon_keys = []
+        if self.owl_statue_setting in {'both', 'dungeon'} and self.dungeon_item_setting in {'', 'keysy', 'smallkeys', 'nightmarekeys'}:
+            dungeon_keys += [item for item in self.getItemListWithMultiplicity() if item.startswith("STONE_BEAK")]
         if self.dungeon_item_setting in {'', 'localkeys', 'nightmarekeys'}:
             dungeon_keys += [item for item in self.getItemListWithMultiplicity() if item.startswith("KEY")]
         if self.dungeon_item_setting in {'', 'localkeys', 'localnightmarekey', 'smallkeys'}:

--- a/randomizer.py
+++ b/randomizer.py
@@ -61,7 +61,7 @@ class Randomizer:
 
         if settings.multiworld:
             item_placer = MultiworldItemPlacer(self.__logic, settings.forwardfactor if settings.forwardfactor > 0.0 else 0.5, settings.accessibility, settings.multiworld)
-        elif settings.dungeon_items in {'', 'localkeys'} or settings.forwardfactor > 0.0 or settings.overworld in {'dungeonchain'}:
+        elif settings.dungeon_items in {'', 'localkeys', 'nightmarekeys'} or settings.forwardfactor > 0.0 or settings.overworld in {'dungeonchain'}:
             item_placer = ForwardItemPlacer(self.__logic, settings.forwardfactor, settings.accessibility)
         else:
             item_placer = RandomItemPlacer(self.__logic, settings.accessibility)

--- a/randomizer.py
+++ b/randomizer.py
@@ -61,10 +61,10 @@ class Randomizer:
 
         if settings.multiworld:
             item_placer = MultiworldItemPlacer(self.__logic, settings.forwardfactor if settings.forwardfactor > 0.0 else 0.5, settings.accessibility, settings.multiworld)
-        elif settings.dungeon_items in {'', 'localkeys', 'nightmarekeys'} or settings.forwardfactor > 0.0 or settings.overworld in {'dungeonchain'}:
+        elif settings.forwardfactor > 0.0 or settings.overworld in {'dungeonchain'}:
             item_placer = ForwardItemPlacer(self.__logic, settings.forwardfactor, settings.accessibility)
         else:
-            item_placer = RandomItemPlacer(self.__logic, settings.accessibility)
+            item_placer = RandomItemPlacer(self.__logic, settings.dungeon_items, settings.accessibility)
         for item, count in self.readItemPool(settings, item_placer).items():
             if count > 0:
                 item_placer.addItem(item, count)
@@ -168,6 +168,12 @@ class ItemPlacer:
         if self._item_pool[item] == 0:
             del self._item_pool[item]
 
+    def getItemListWithMultiplicity(self) -> List[str]:
+        item_list = []
+        for item, count in self._item_pool.items():
+            item_list += [item for _ in range(count)]
+        return item_list
+
     def addSpot(self, spot: locations.itemInfo.ItemInfo) -> None:
         self._spots.append(spot)
 
@@ -223,14 +229,32 @@ class ItemPlacer:
 
 
 class RandomItemPlacer(ItemPlacer):
+    def __init__(self, logic: logic.Logic, dungeon_item_setting: str, accessibility: str) -> None:
+        super().__init__(logic, accessibility)
+        self.dungeon_item_setting = dungeon_item_setting
+
     def run(self, rnd: random.Random) -> None:
         assert sum(self._item_pool.values()) == len(self._spots), "%d != %d" % (sum(self._item_pool.values()), len(self._spots))
         assert self.logicStillValid(), "Sanity check failed: %s" % (self.logicStillValid(verbose=True))
 
+        # Place keys that are restricted to their dungeon first to avoid running out of valid spots
+        dungeon_keys = []
+        if self.dungeon_item_setting in {'', 'localkeys', 'nightmarekeys'}:
+            dungeon_keys += [item for item in self.getItemListWithMultiplicity() if item.startswith("KEY")]
+        if self.dungeon_item_setting in {'', 'localkeys', 'localnightmarekey', 'smallkeys'}:
+            dungeon_keys += [item for item in self.getItemListWithMultiplicity() if item.startswith("NIGHTMARE_KEY")]
+        rnd.shuffle(dungeon_keys)
+
         bail_counter = 0
         while self._item_pool:
             assert sum(self._item_pool.values()) == len(self._spots)
-            if not self.__placeItem(rnd):
+            if dungeon_keys:
+                success = self.placeSpecificItem(dungeon_keys[0], rnd)
+                if success:
+                    dungeon_keys.pop(0)
+            else:
+                success = self.__placeItem(rnd)
+            if not success:
                 bail_counter += 1
                 if bail_counter > 10:
                     raise Error("Failed to place an item for a bunch of retries")
@@ -244,6 +268,24 @@ class RandomItemPlacer(ItemPlacer):
         if not options:
             return False
         item = rnd.choice(options)
+
+        spot.item = item
+        self.removeItem(item)
+        self.removeSpot(spot)
+
+        if not self.logicStillValid():
+            spot.item = None
+            self.addItem(item)
+            self.addSpot(spot)
+            #print("Failed to place:", item)
+            return False
+        #print("Placed:", item)
+        return True
+
+    def placeSpecificItem(self, item: str, rnd: random.Random) -> bool:
+        # Random placement of a given item
+        spot_options = [spot for spot in self._spots if item in spot.getOptions()]
+        spot = rnd.choice(spot_options)
 
         spot.item = item
         self.removeItem(item)

--- a/settings.py
+++ b/settings.py
@@ -125,6 +125,7 @@ Spoiler logs can not be generated for ROMs generated with race mode enabled, and
 [Gift], You get a random gift of any item, and the boomerang is shuffled."""),
             Setting('dungeon_items', 'Gameplay', 'D', 'Dungeon items', options=[('', '', 'Standard'),
                                                                           ('smallkeys', 's', 'Small keys'),
+                                                                          ('nightmarekeys', 'n', 'Nightmare keys'),
                                                                           ('localkeys', 'L', 'Map/Compass/Beaks'),
                                                                           ('localnightmarekey', 'N', 'MCB + SmallKeys'),
                                                                           ('keysanity', 'K', 'Keysanity'),

--- a/www/js/options.js
+++ b/www/js/options.js
@@ -208,6 +208,11 @@ var options =
     "label": "Small keys"
    },
    {
+    "key": "nightmarekeys",
+    "short": "n",
+    "label": "Nightmare keys"
+   },
+   {
     "key": "localkeys",
     "short": "L",
     "label": "Map/Compass/Beaks"


### PR DESCRIPTION
The RandomItemPlacer class is changed to place the keys that have to remain in their own dungeons first. (Beaks can also count as keys depending on the Owl Statues option.) This avoids the issue of running out of valid spots to place keys in.
All dungeon item options are now supported by the RandomItemPlacer.

The dungeon item options "Standard" and "Map/Compass/Beaks" now use the RandomItemPlacer by default (so when no positive forward factor is provided, and not in dungeon chain mode, and not in Multiworld). This means the item distribution will be noticeably different from before when the ForwardItemPlacer always had to be used.
The dungeon item options "Small keys" and "MCB + SmallKeys" should in theory have a very slightly different distribution to before when keys in dungeons could be placed at any point, but it's hard to tell without an analysis of mass-generated seeds. Generation now takes fewer retries.

Also, a new option "Nightmare keys" is added.

Side note: It appears like the RandomItemPlacer could now handle D3 relatively well without forcing keys in area_left and area_south, but I didn't want to change anything in the logic, and also the ForwardItemPlacer is still struggling with it.