### PR TITLE
Restore vanilla map when rooster is an item

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -131,7 +131,9 @@ def generateRom(args, settings, seed, logic, *, rnd=None, multiworld=None):
     if settings.witch:
         patches.witch.updateWitch(rom)
     patches.softlock.fixAll(rom)
-    patches.maptweaks.tweakMap(rom)
+    if not settings.rooster:
+        patches.maptweaks.tweakMap(rom)
+        patches.maptweaks.tweakBirdKeyRoom(rom)
     patches.chest.fixChests(rom)
     patches.shop.fixShop(rom)
     patches.rooster.patchRooster(rom)

--- a/locations/birdKey.py
+++ b/locations/birdKey.py
@@ -1,23 +1,7 @@
 from .droppedKey import DroppedKey
-from roomEditor import RoomEditor
-from assembler import ASM
 
 
 class BirdKey(DroppedKey):
     def __init__(self):
         super().__init__(0x27A)
 
-    def patch(self, rom, option, *, multiworld=None):
-        super().patch(rom, option, multiworld=multiworld)
-
-        re = RoomEditor(rom, self.room)
-
-        # Make the bird key accessible without the rooster
-        re.removeObject(1, 6)
-        re.removeObject(2, 6)
-        re.removeObject(3, 5)
-        re.removeObject(3, 6)
-        re.moveObject(1, 5, 2, 6)
-        re.moveObject(2, 5, 3, 6)
-        re.addEntity(3, 5, 0x9D)
-        re.store(rom)

--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -168,7 +168,9 @@ class World:
         prairie_island_seashell = Location().add(Seashell(0x0A6)).connect(ukuku_prairie, AND(FLIPPERS, r.bush))  # next to lv3
         seashell_mansion_bush = Location().add(Seashell(0x08B)).connect(ukuku_prairie, r.bush)
         Location().add(Seashell(0x0A4)).connect(ukuku_prairie, PEGASUS_BOOTS)  # smash into tree next to phonehouse
-        self._addEntrance("castle_jump_cave", ukuku_prairie, Location().add(Chest(0x1FD)), OR(AND(FEATHER, PEGASUS_BOOTS), ROOSTER)) # left of the castle, 5 holes turned into 3
+        self._addEntrance("castle_jump_cave", ukuku_prairie, Location().add(Chest(0x1FD)), ROOSTER)
+        if not options.rooster:
+            self._addEntranceRequirement("castle_jump_cave", AND(FEATHER, PEGASUS_BOOTS)) # left of the castle, 5 holes turned into 3
         Location().add(Seashell(0x0B9)).connect(ukuku_prairie, POWER_BRACELET)  # under the rock
 
         left_bay_area = Location()
@@ -384,7 +386,9 @@ class World:
         self._addEntrance("rooster_house", outside_rooster_house, None, None)
         bird_cave = Location()
         bird_key = Location().add(BirdKey())
-        bird_cave.connect(bird_key, OR(AND(FEATHER, COUNT(POWER_BRACELET, 2)), ROOSTER))
+        bird_cave.connect(bird_key, ROOSTER)
+        if not options.rooster:
+            bird_cave.connect(bird_key, AND(FEATHER, COUNT(POWER_BRACELET, 2))) # elephant statue added
         if options.logic != "casual":
             bird_cave.connect(lower_right_taltal, None, one_way=True)  # Drop in a hole at bird cave
         self._addEntrance("bird_cave", outside_rooster_house, bird_cave, None)
@@ -486,7 +490,8 @@ class World:
             
             d6_connector_left.connect(d6_connector_right, AND(OR(FLIPPERS, PEGASUS_BOOTS), FEATHER))  # jump the gap in underground passage to d6 left side to skip hookshot
             obstacle_cave_exit.connect(obstacle_cave_inside, AND(FEATHER, r.hookshot_over_pit), one_way=True) # one way from right exit to middle, jump past the obstacle, and use hookshot to pull past the double obstacle
-            bird_key.connect(bird_cave, COUNT(POWER_BRACELET, 2))  # corner walk past the one pit on the left side to get to the elephant statue
+            if not options.rooster:
+                bird_key.connect(bird_cave, COUNT(POWER_BRACELET, 2))  # corner walk past the one pit on the left side to get to the elephant statue
             fire_cave_bottom.connect(fire_cave_top, AND(r.damage_boost, PEGASUS_BOOTS), one_way=True) # flame skip
 
         if options.logic == 'glitched' or options.logic == 'hell':

--- a/patches/maptweaks.py
+++ b/patches/maptweaks.py
@@ -25,3 +25,16 @@ def addBetaRoom(rom):
     re.store(rom)
 
     rom.room_sprite_data_indoor[0x0FC] = rom.room_sprite_data_indoor[0x1A1]
+
+
+def tweakBirdKeyRoom(rom):
+    # Make the bird key accessible without the rooster
+    re = RoomEditor(rom, 0x27A)
+    re.removeObject(1, 6)
+    re.removeObject(2, 6)
+    re.removeObject(3, 5)
+    re.removeObject(3, 6)
+    re.moveObject(1, 5, 2, 6)
+    re.moveObject(2, 5, 3, 6)
+    re.addEntity(3, 5, 0x9D)
+    re.store(rom)

--- a/settings.py
+++ b/settings.py
@@ -117,7 +117,7 @@ Spoiler logs can not be generated for ROMs generated with race mode enabled, and
             Setting('witch', 'Items', 'W', 'Randomize item given by the witch', default=True,
                 description='Adds both the toadstool and the reward for giving the toadstool to the witch to the item pool'),
             Setting('rooster', 'Items', 'R', 'Add the rooster', default=True,
-                description='Adds the rooster to the item pool. Without this option, the rooster spot is still a check giving an item. But you will never find the rooster. Any rooster spot is accessible without rooster by other means.'),
+                description='Adds the rooster to the item pool. Without this option, the rooster spot is still a check giving an item. But you will never find the rooster. In that case, any rooster spot is accessible without rooster by other means.'),
             Setting('boomerang', 'Items', 'Z', 'Boomerang trade', options=[('default', 'd', 'Normal'), ('trade', 't', 'Trade'), ('gift', 'g', 'Gift')], default='gift',
                 description="""
 [Normal], requires magnifier to get the boomerang.

--- a/www/js/options.js
+++ b/www/js/options.js
@@ -155,7 +155,7 @@ var options =
   "category": "Items",
   "short_key": "R",
   "label": "Add the rooster",
-  "description": "Adds the rooster to the item pool. Without this option, the rooster spot is still a check giving an item. But you will never find the rooster. Any rooster spot is accessible without rooster by other means.",
+  "description": "Adds the rooster to the item pool. Without this option, the rooster spot is still a check giving an item. But you will never find the rooster. In that case, any rooster spot is accessible without rooster by other means.",
   "multiworld": true,
   "aesthetic": false,
   "default": true


### PR DESCRIPTION
When the rooster is in the item pool, the map changes made for the Bird Key location and the Kanalet Castle Boots Pit are no longer needed and the vanilla behavior of requiring the rooster (or glitches) for these locations can be restored.
This change of course affects both the logic and the patch.
This has been suggested before on the Discord.