### PR TITLE
Allow readEntrances to correctly read screens with multiple entrances

### DIFF
--- a/entranceInfo.py
+++ b/entranceInfo.py
@@ -1,6 +1,6 @@
 
 class EntranceInfo:
-    def __init__(self, room, alt_room=None, *, type=None, dungeon=None, index=None, instrument_room=None, target=None):
+    def __init__(self, room, alt_room=None, *, type=None, dungeon=None, index=None, instrument_room=None, target=None, x=None, y=None):
         if type is None and dungeon is not None:
             type = "dungeon"
         assert type is not None, "Missing entrance type"
@@ -11,6 +11,8 @@ class EntranceInfo:
         self.index = index
         self.instrument_room = instrument_room
         self.target = target
+        self.x = x
+        self.y = y
 
 
 ENTRANCE_INFO = {
@@ -23,22 +25,22 @@ ENTRANCE_INFO = {
     "left_taltal_entrance":         EntranceInfo(0x15, target=0x2ea, type="connector"),
     "obstacle_cave_entrance":       EntranceInfo(0x17, target=0x2b6, type="connector"),
     "left_to_right_taltalentrance": EntranceInfo(0x07, target=0x2ee, type="connector"),
-    "obstacle_cave_outside_chest":  EntranceInfo(0x18, target=0x2bb, type="connector", index=0),
-    "obstacle_cave_exit":           EntranceInfo(0x18, target=0x2bc, type="connector", index=1),
+    "obstacle_cave_outside_chest":  EntranceInfo(0x18, target=0x2bb, type="connector", index=0, x=104, y=18),
+    "obstacle_cave_exit":           EntranceInfo(0x18, target=0x2bc, type="connector", index=1, x=136, y=18),
     "papahl_entrance":              EntranceInfo(0x19, target=0x289, type="connector"),
-    "papahl_exit":                  EntranceInfo(0x0A, target=0x28b, type="connector", index=0),
-    "rooster_house":                EntranceInfo(0x0A, target=0x29f, type="dummy", index=2),
-    "bird_cave":                    EntranceInfo(0x0A, target=0x27e, type="single", index=1),
-    "multichest_left":              EntranceInfo(0x1D, target=0x2f9, type="connector", index=0),
-    "multichest_right":             EntranceInfo(0x1D, target=0x2fa, type="connector", index=1),
+    "papahl_exit":                  EntranceInfo(0x0A, target=0x28b, type="connector", index=0, x=24, y=112),
+    "rooster_house":                EntranceInfo(0x0A, target=0x29f, type="dummy", index=2, x=72, y=34),
+    "bird_cave":                    EntranceInfo(0x0A, target=0x27e, type="single", index=1, x=120, y=112),
+    "multichest_left":              EntranceInfo(0x1D, target=0x2f9, type="connector", index=0, x=24, y=48),
+    "multichest_right":             EntranceInfo(0x1D, target=0x2fa, type="connector", index=1, x=120, y=80),
     "multichest_top":               EntranceInfo(0x0D, target=0x2f2, type="connector"),
-    "right_taltal_connector1":      EntranceInfo(0x1E, target=0x280, type="connector", index=0),
-    "right_taltal_connector2":      EntranceInfo(0x1F, target=0x282, type="connector", index=0),
-    "right_taltal_connector3":      EntranceInfo(0x1E, target=0x283, type="connector", index=1),
-    "right_taltal_connector4":      EntranceInfo(0x1F, target=0x287, type="connector", index=2),
-    "right_taltal_connector5":      EntranceInfo(0x1F, target=0x28c, type="connector", index=1),
+    "right_taltal_connector1":      EntranceInfo(0x1E, target=0x280, type="connector", index=0, x=56, y=16),
+    "right_taltal_connector2":      EntranceInfo(0x1F, target=0x282, type="connector", index=0, x=40, y=16),
+    "right_taltal_connector3":      EntranceInfo(0x1E, target=0x283, type="connector", index=1, x=120, y=16),
+    "right_taltal_connector4":      EntranceInfo(0x1F, target=0x287, type="connector", index=2, x=88, y=64),
+    "right_taltal_connector5":      EntranceInfo(0x1F, target=0x28c, type="connector", index=1, x=120, y=16),
     "right_taltal_connector6":      EntranceInfo(0x0F, target=0x28e, type="connector"),
-    "right_fairy":                  EntranceInfo(0x1F, target=0x1fb, type="dummy", index=3),
+    "right_fairy":                  EntranceInfo(0x1F, target=0x1fb, type="dummy", index=3, x=56, y=80),
     "d7":                           EntranceInfo(0x0E, "Alt0E", target=0x20e, dungeon=7, instrument_room=0x22C),
     # Row 2-3
     "writes_cave_left":             EntranceInfo(0x20, target=0x2ae, type="connector"),
@@ -49,7 +51,7 @@ ENTRANCE_INFO = {
     "moblin_cave":                  EntranceInfo(0x35, target=0x2f0, type="single"),
     "photo_house":                  EntranceInfo(0x37, target=0x2b5, type="dummy"),
     "mambo":                        EntranceInfo(0x2A, target=0x2fd, type="water"),
-    "d4":                           EntranceInfo(0x2B, "Alt2B", target=0x17a, dungeon=4, index=0, instrument_room=0x162),
+    "d4":                           EntranceInfo(0x2B, "Alt2B", target=0x17a, dungeon=4, index=0, x=72, y=34, instrument_room=0x162),
     # TODO
     #  "d4_connector":                 EntranceInfo(0x2B, "Alt2B", index=1),
     #  "d4_connector_exit":            EntranceInfo(0x2D),
@@ -70,19 +72,19 @@ ENTRANCE_INFO = {
     # Castle
     "castle_jump_cave":             EntranceInfo(0x78, target=0x1fd, type="single"),
     "castle_main_entrance":         EntranceInfo(0x69, target=0x2d3, type="connector"),
-    "castle_upper_left":            EntranceInfo(0x59, target=0x2d5, type="connector", index=0),
-    "castle_upper_right":           EntranceInfo(0x59, target=0x2d6, type="single", index=1),
+    "castle_upper_left":            EntranceInfo(0x59, target=0x2d5, type="connector", index=0, x=24, y=48),
+    "castle_upper_right":           EntranceInfo(0x59, target=0x2d6, type="single", index=1, x=88, y=64),
     "castle_secret_exit":           EntranceInfo(0x49, target=0x1eb, type="connector"),
     "castle_secret_entrance":       EntranceInfo(0x4A, target=0x1ec, type="connector"),
     "castle_phone":                 EntranceInfo(0x4B, target=0x2cc, type="dummy"),
     # Mabe village
-    "papahl_house_left":            EntranceInfo(0x82, target=0x2a5, type="connector", index=0),
-    "papahl_house_right":           EntranceInfo(0x82, target=0x2a6, type="connector", index=1),
+    "papahl_house_left":            EntranceInfo(0x82, target=0x2a5, type="connector", index=0, x=88, y=82),
+    "papahl_house_right":           EntranceInfo(0x82, target=0x2a6, type="connector", index=1, x=120, y=82),
     "dream_hut":                    EntranceInfo(0x83, target=0x2aa, type="single"),
     "rooster_grave":                EntranceInfo(0x92, target=0x1f4, type="single"),
     "shop":                         EntranceInfo(0x93, target=0x2a1, type="single"),
-    "madambowwow":                  EntranceInfo(0xA1, target=0x2a7, type="dummy", index=1),
-    "kennel":                       EntranceInfo(0xA1, target=0x2b2, type="single", index=0),
+    "madambowwow":                  EntranceInfo(0xA1, target=0x2a7, type="dummy", index=1, x=56, y=66),
+    "kennel":                       EntranceInfo(0xA1, target=0x2b2, type="single", index=0, x=88, y=66),
     "start_house":                  EntranceInfo(0xA2, target=0x2a3, type="start"),
     "library":                      EntranceInfo(0xB0, target=0x1fa, type="dummy"),
     "ulrira":                       EntranceInfo(0xB1, target=0x2a9, type="dummy"),
@@ -97,9 +99,9 @@ ENTRANCE_INFO = {
     "d3":                           EntranceInfo(0xB5, target=0x152, dungeon=3, instrument_room=0x159),
     "prairie_right_phone":          EntranceInfo(0x88, target=0x29c, type="dummy"),
     "seashell_mansion":             EntranceInfo(0x8A, target=0x2e9, type="single"),
-    "prairie_right_cave_top":       EntranceInfo(0xB8, target=0x292, type="connector", index=1),
+    "prairie_right_cave_top":       EntranceInfo(0xB8, target=0x292, type="connector", index=1, x=120, y=96),
     "prairie_right_cave_bottom":    EntranceInfo(0xC8, target=0x293, type="connector"),
-    "prairie_right_cave_high":      EntranceInfo(0xB8, target=0x295, type="connector", index=0),
+    "prairie_right_cave_high":      EntranceInfo(0xB8, target=0x295, type="connector", index=0, x=88, y=48),
     "prairie_to_animal_connector":  EntranceInfo(0xAA, target=0x2d0, type="connector"),
     "animal_to_prairie_connector":  EntranceInfo(0xAB, target=0x2d1, type="connector"),
     
@@ -126,11 +128,11 @@ ENTRANCE_INFO = {
     "d5":                           EntranceInfo(0xD9, target=0x1a1, dungeon=5, instrument_room=0x182),
     # Animal village
     "animal_phone":                 EntranceInfo(0xDB, target=0x2e3, type="dummy"),
-    "animal_house1":                EntranceInfo(0xCC, target=0x2db, type="dummy", index=0),
-    "animal_house2":                EntranceInfo(0xCC, target=0x2dd, type="dummy", index=1),
-    "animal_house3":                EntranceInfo(0xCD, target=0x2d9, type="trade", index=1),
-    "animal_house4":                EntranceInfo(0xCD, target=0x2da, type="dummy", index=2),
+    "animal_house1":                EntranceInfo(0xCC, target=0x2db, type="dummy", index=0, x=40, y=80),
+    "animal_house2":                EntranceInfo(0xCC, target=0x2dd, type="dummy", index=1, x=120, y=80),
+    "animal_house3":                EntranceInfo(0xCD, target=0x2d9, type="trade", index=1, x=40, y=80),
+    "animal_house4":                EntranceInfo(0xCD, target=0x2da, type="dummy", index=2, x=88, y=80),
     "animal_house5":                EntranceInfo(0xDD, target=0x2d7, type="trade"),
-    "animal_cave":                  EntranceInfo(0xCD, target=0x2f7, type="single", index=0),
+    "animal_cave":                  EntranceInfo(0xCD, target=0x2f7, type="single", index=0, x=136, y=32),
     "desert_cave":                  EntranceInfo(0xCF, target=0x1f9, type="single"),
 }

--- a/patches/entrances.py
+++ b/patches/entrances.py
@@ -66,6 +66,9 @@ def readEntrances(rom):
         for other_key, other_info in ENTRANCE_INFO.items():
             if warp.room == other_info.target:
                 result[f"{key}:inside"] = f"{other_key}:inside"
-            if warp.room == other_info.room:
+            if (warp.room == other_info.room
+                and (other_info.x == None
+                     or (other_info.x == warp.target_x
+                         and other_info.y == warp.target_y))):
                 result[f"{key}:inside"] = other_key
     return result


### PR DESCRIPTION
This correctly maps warps that target rooms that have multiple entrances (e.g. `'rooster_house:inside': 'rooster_house'` instead of `'rooster_house:inside': 'bird_cave'` before).

I didn't see a way to do this with the existing data, but I'm happy to rework it if I missed a better way to do this.