### PR TITLE
Make bonus seashells not missable and randomize them

### DIFF
--- a/checkMetadata.py
+++ b/checkMetadata.py
@@ -204,6 +204,8 @@ checkMetadataTable = {
     "0x0A6": CheckMetadata("Outside D3 Island Bush", "Ukuku Prairie"), #http://artemis251.fobby.net/zelda/maps/overworld/00A6.GIF
     "0x08B": CheckMetadata("East of Seashell Mansion Bush", "Ukuku Prairie"), #http://artemis251.fobby.net/zelda/maps/overworld/008B.GIF
     "0x0A4": CheckMetadata("East of Mabe Tree Bonk", "Ukuku Prairie"), #http://artemis251.fobby.net/zelda/maps/overworld/00A4.GIF
+    "0x2E9-0": CheckMetadata("Seashell Mansion 5 Bonus", "Ukuku Prairie"),
+    "0x2E9-1": CheckMetadata("Seashell Mansion 10 Bonus", "Ukuku Prairie"),
     "0x2E9": CheckMetadata("Seashell Mansion", "Ukuku Prairie"),
     "0x1FD": CheckMetadata("Boots Pit", "Kanalet Castle"), #http://artemis251.fobby.net/zelda/maps/underworld1/01FD.GIF
     "0x0B9": CheckMetadata("Rock Seashell", "Donut Plains"), #http://artemis251.fobby.net/zelda/maps/overworld/00B9.GIF

--- a/docs/plan-template.txt
+++ b/docs/plan-template.txt
@@ -175,6 +175,10 @@ Location:0x0A6:
 Location:0x0A5: 
 ;Ukuku Prairie - Seashell Mansion
 Location:0x2E9: 
+;Ukuku Prairie - Seashell Mansion 5 Bonus
+Location:0x2E9-0: 
+;Ukuku Prairie - Seashell Mansion 10 Bonus
+Location:0x2E9-1: 
 ;Yarna Desert - Bomb Arrow Cave
 Location:0x2E6: 
 ;Yarna Desert - Cave Under Lanmola

--- a/itempool.py
+++ b/itempool.py
@@ -35,7 +35,7 @@ DEFAULT_ITEM_POOL = {
     RUPEES_200: 3,
     RUPEES_50: 19,
 
-    SEASHELL: 24,
+    SEASHELL: 26,
     MEDICINE: 3,
     GEL: 4,
     MESSAGE: 1,
@@ -121,6 +121,9 @@ class ItemPool:
         elif settings.hpmode == 'extralow':
             self.add(RUPEES_20, self.get(HEART_CONTAINER))
             self.remove(HEART_CONTAINER, self.get(HEART_CONTAINER))
+        
+        if settings.goal == 'seashells':
+            self.remove(SEASHELL, 2)
 
         if settings.itempool == 'casual':
             self.add(SWORD)

--- a/locations/all.py
+++ b/locations/all.py
@@ -1,7 +1,7 @@
 from .beachSword import BeachSword
 from .chest import Chest, DungeonChest
 from .droppedKey import DroppedKey
-from .seashell import Seashell, SeashellMansion
+from .seashell import Seashell, SeashellMansionBonus, SeashellMansion
 from .heartContainer import HeartContainer
 from .owlStatue import OwlStatue
 from .madBatter import MadBatter

--- a/locations/seashell.py
+++ b/locations/seashell.py
@@ -1,4 +1,6 @@
+from .itemInfo import ItemInfo
 from .droppedKey import DroppedKey
+from .constants import *
 from .items import *
 
 
@@ -8,6 +10,44 @@ class Seashell(DroppedKey):
     def configure(self, options):
         if not options.seashells:
             self.OPTIONS = [SEASHELL]
+
+
+class SeashellMansionBonus(ItemInfo):
+    OPTIONS = [POWER_BRACELET, SHIELD, BOW, HOOKSHOT, MAGIC_ROD, PEGASUS_BOOTS, OCARINA,
+        FEATHER, SHOVEL, MAGIC_POWDER, BOMB, SWORD, FLIPPERS, MAGNIFYING_LENS, MEDICINE,
+        TAIL_KEY, ANGLER_KEY, FACE_KEY, BIRD_KEY, GOLD_LEAF, SLIME_KEY, ROOSTER, HAMMER,
+        RUPEES_50, RUPEES_20, RUPEES_100, RUPEES_200, RUPEES_500,
+        SEASHELL, MESSAGE, BOOMERANG, HEART_PIECE, BOWWOW, ARROWS_10, SINGLE_ARROW,
+        MAX_POWDER_UPGRADE, MAX_BOMBS_UPGRADE, MAX_ARROWS_UPGRADE, RED_TUNIC, BLUE_TUNIC,
+        HEART_CONTAINER, BAD_HEART_CONTAINER, TOADSTOOL, SONG1, SONG2, SONG3,
+        INSTRUMENT1, INSTRUMENT2, INSTRUMENT3, INSTRUMENT4, INSTRUMENT5, INSTRUMENT6, INSTRUMENT7, INSTRUMENT8,
+        TRADING_ITEM_YOSHI_DOLL, TRADING_ITEM_RIBBON, TRADING_ITEM_DOG_FOOD, TRADING_ITEM_BANANAS, TRADING_ITEM_STICK,
+        TRADING_ITEM_HONEYCOMB, TRADING_ITEM_PINEAPPLE, TRADING_ITEM_HIBISCUS, TRADING_ITEM_LETTER, TRADING_ITEM_BROOM,
+        TRADING_ITEM_FISHING_HOOK, TRADING_ITEM_NECKLACE, TRADING_ITEM_SCALE, TRADING_ITEM_MAGNIFYING_GLASS
+    ]
+
+    def __init__(self, index):
+        self.index = index
+        super().__init__(0x2E9)
+
+    def patch(self, rom, option, *, multiworld=None):
+        assert multiworld is None
+        rom.banks[0x3E][0x3E30 + self.index] = CHEST_ITEMS[option]
+
+    def read(self, rom):
+        value = rom.banks[0x3E][0x3E30 + self.index]
+        for k, v in CHEST_ITEMS.items():
+            if v == value:
+                return k
+        raise ValueError("Could not find bonus seashell contents in ROM (0x%02x)" % (value))
+
+    def configure(self, options):
+        if not options.seashells:
+            self.OPTIONS = [SEASHELL]
+
+    @property
+    def nameId(self):
+        return "0x%03X-%s" % (self.room, self.index)
 
 
 class SeashellMansion(DroppedKey):

--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -201,6 +201,8 @@ class World:
 
         seashell_mansion = Location()
         if options.goal != "seashells":
+            Location().add(SeashellMansionBonus(0)).connect(seashell_mansion, COUNT(SEASHELL, 5))
+            Location().add(SeashellMansionBonus(1)).connect(seashell_mansion, COUNT(SEASHELL, 10))
             Location().add(SeashellMansion(0x2E9)).connect(seashell_mansion, COUNT(SEASHELL, 20))
         else:
             seashell_mansion.add(DroppedKey(0x2E9))
@@ -728,7 +730,12 @@ class ALttP:
         self._addEntrance("start_house", start_area, start_house, None)
         Location().add(Song(0x092)).connect(start_area, AND(OCARINA, r.bush))  # Marins song
         seashell_mansion = Location()
-        Location().add(SeashellMansion(0x2E9)).connect(seashell_mansion, COUNT(SEASHELL, 20))
+        if options.goal != "seashells":
+            Location().add(SeashellMansionBonus(0)).connect(seashell_mansion, COUNT(SEASHELL, 5))
+            Location().add(SeashellMansionBonus(1)).connect(seashell_mansion, COUNT(SEASHELL, 10))
+            Location().add(SeashellMansion(0x2E9)).connect(seashell_mansion, COUNT(SEASHELL, 20))
+        else:
+            seashell_mansion.add(DroppedKey(0x2E9))
         self._addEntrance("seashell_mansion", start_area, seashell_mansion, None)
 
         start_area.add(Seashell(0x4A))

--- a/patches/bank3e.asm/chest.asm
+++ b/patches/bank3e.asm/chest.asm
@@ -1018,6 +1018,45 @@ RenderItemForRoom:
     ldh  [$FFF1], a
     jp   RenderChestItem
 
+HandleSeashellMansionItem:
+    ld   a, b
+    cp   $05 ; check if modified seashell count is 5
+    jr   nz, .checkSecond
+    ld   a, [$7E30]
+    jr   .giveItem
+.checkSecond:
+    cp   $10
+    ret  nz
+    ld   a, [$7E31]
+.giveItem:
+    ldh  [$FFF1], a
+    push bc
+    call ItemMessage
+    call GiveItemFromChest
+    ; For player convenience, check if another reward is available
+    pop  af
+    cp   $05
+    jr   z, .check10
+.check20:
+    ld   a, [wSeashellsCount]
+    cp   $20
+    jr   nc, .resetMansionState
+    ret
+.check10:
+    ld   a, [wSeashellsCount]
+    cp   $10
+    ret  c
+.resetMansionState:
+    ; For safety, make sure we have the expected entity and state
+    ld   a, [$C3A0]
+    cp   $CF
+    ret  nz
+    ld   a, [$C290]
+    sub  $07
+    ret  nz
+    ld   [$C290], a
+    ret
+
 ; Increase the amount of checks we completed, unless we are on the multichest room.
 IncreaseCheckCounter:
     ldh  a, [$FFF6] ; map room

--- a/patches/bank3e.asm/main.asm
+++ b/patches/bank3e.asm/main.asm
@@ -21,6 +21,7 @@ MainJumpTable:
         dw   GiveItemAndMessageForRoomMultiworld  ; E
         dw   RenderOwlStatueItem                  ; F
         dw   UpdateInventoryMenu                  ; 10
+        dw   HandleSeashellMansionItem            ; 11
 
 StartGameMarinMessage:
         ; Injection to reset our frame counter

--- a/patches/bank3e.py
+++ b/patches/bank3e.py
@@ -56,6 +56,7 @@ def addBank3E(rom, seed, settings):
     # 3E:3300-3616: Multiworld flags per room (for both chests and dropped keys)
     # 3E:3800-3B16: DroppedKey item types
     # 3E:3B16-3E2C: Owl statue or trade quest items
+    # 3E:3E30-3E32: 5 and 10 seashell rewards
 
     # Put 20 rupees in all owls by default.
     rom.patch(0x3E, 0x3B16, "00" * 0x316, "1C" * 0x316)

--- a/patches/goal.py
+++ b/patches/goal.py
@@ -29,7 +29,7 @@ def setRequiredInstrumentCount(rom, count):
         jp   $7F2B ; jump to the end of the bank, where there is some space for code.
     """), fill_nop=True)
     # Add some code at the end of the bank, as we do not have enough space to do this "in place"
-    rom.patch(0x19, 0x3F2B, "0000000000000000000000000000000000000000000000000000", ASM("""
+    rom.patch(0x19, 0x3F2B, "00" * 26, ASM("""
         ld   d, $00
         ld   e, $08
         ld   hl, $DB65 ; start of has instrument memory
@@ -47,7 +47,7 @@ noinc:
         jp   c, $4C1A ; not enough instruments
         jp   $4C0B    ; enough instruments
     """ % (count)), fill_nop=True)
-    rom.patch(0x19, 0x3FE0, "0000000000000000000000000000000000000000000000000000", ASM("""
+    rom.patch(0x19, 0x3FE0, "00" * 26, ASM("""
     ; Entry point of render code
         ld   hl, $DB65  ; table of having instruments
         push bc
@@ -70,7 +70,7 @@ def setSpecificInstruments(rom, instruments):
     for n in range(2, len(instruments)):
         code += f"ld l, $65 + {instruments[n] - 1}\nand [hl]\n"
     code += "and $02\njp z, $4C1A\njp $4C0B"
-    rom.patch(0x19, 0x3F2B, "0000000000000000000000000000000000000000000000000000", ASM(code), fill_nop=True)
+    rom.patch(0x19, 0x3F2B, "00" * 26, ASM(code), fill_nop=True)
     rom.patch(0x19, 0x0BFE, 0x0C0B, ASM("jp $7F2B"), fill_nop=True)
 
 

--- a/patches/seashell.py
+++ b/patches/seashell.py
@@ -66,12 +66,12 @@ def upgradeMansion(rom):
     # Do not reset seashell counter
     rom.patch(0x19, 0x3700, ASM("ld [wSeashellsCount], a"), "", fill_nop=True)
     # Prevent missing out on a reward or getting the last reward multiple times
-    rom.patch(0x19, 0x31CA, ASM("ld a, [wSeashellsCount]"), ASM("call $7F30"))
-    rom.patch(0x19, 0x3215, ASM("ld a, [wSeashellsCount]"), ASM("call $7F30"))
-    rom.patch(0x19, 0x32A2, ASM("ld a, [wSeashellsCount]"), ASM("call $7F30"))
-    rom.patch(0x19, 0x38B3, ASM("ld a, [wSeashellsCount]"), ASM("call $7F30"))
+    rom.patch(0x19, 0x31CA, ASM("ld a, [wSeashellsCount]"), ASM("call $7F50"))
+    rom.patch(0x19, 0x3215, ASM("ld a, [wSeashellsCount]"), ASM("call $7F50"))
+    rom.patch(0x19, 0x32A2, ASM("ld a, [wSeashellsCount]"), ASM("call $7F50"))
+    rom.patch(0x19, 0x38B3, ASM("ld a, [wSeashellsCount]"), ASM("call $7F50"))
     # This is using free space in bank 0x19 because we need to return a value in A when called
-    rom.patch(0x19, 0x3F30, "00" * 0x30, ASM("""
+    rom.patch(0x19, 0x3F50, "00" * 0x30, ASM("""
     ; Maybe pretend like we have fewer seashells to prevent skipping a reward,
     ; or to prevent giving the final reward multiple times
         ld   a, [$DAE9] ; event flags for seashell mansion

--- a/patches/seashell.py
+++ b/patches/seashell.py
@@ -71,7 +71,7 @@ def upgradeMansion(rom):
     rom.patch(0x19, 0x32A2, ASM("ld a, [wSeashellsCount]"), ASM("call $7F30"))
     rom.patch(0x19, 0x38B3, ASM("ld a, [wSeashellsCount]"), ASM("call $7F30"))
     # This is using free space in bank 0x19 because we need to return a value in A when called
-    rom.patch(0x19, 0x3F30, 0x3F60, ASM("""
+    rom.patch(0x19, 0x3F30, "00" * 0x30, ASM("""
     ; Maybe pretend like we have fewer seashells to prevent skipping a reward,
     ; or to prevent giving the final reward multiple times
         ld   a, [$DAE9] ; event flags for seashell mansion

--- a/settings.py
+++ b/settings.py
@@ -107,7 +107,7 @@ Spoiler logs can not be generated for ROMs generated with race mode enabled, and
             Setting('heartpiece', 'Items', 'h', 'Randomize heart pieces', default=True,
                 description='Includes heart pieces in the item pool'),
             Setting('seashells', 'Items', 's', 'Randomize hidden seashells', default=True,
-                description='Randomizes the secret sea shells hiding in the ground/trees. (chest are always randomized)'),
+                description='Randomizes the secret sea shells hiding in the ground/trees/mansion. (chests are always randomized)'),
             Setting('heartcontainers', 'Items', 'H', 'Randomize heart containers', default=True,
                 description='Includes boss heart container drops in the item pool'),
             Setting('instruments', 'Items', 'I', 'Randomize instruments', default=False,

--- a/www/js/options.js
+++ b/www/js/options.js
@@ -105,7 +105,7 @@ var options =
   "category": "Items",
   "short_key": "s",
   "label": "Randomize hidden seashells",
-  "description": "Randomizes the secret sea shells hiding in the ground/trees. (chest are always randomized)",
+  "description": "Randomizes the secret sea shells hiding in the ground/trees/mansion. (chests are always randomized)",
   "multiworld": true,
   "aesthetic": false,
   "default": true


### PR DESCRIPTION
The 2 bonus seashells you get for bringing 5 or 10 seashells to the seashell mansion are now randomized (unless hidden seashells are set to vanilla). This brings the number of seashells in the default item pool up to 26 (it remains at 24 for seashell hunts).

To make this work, these rewards are no longer missable as you do not need an exact number of seashells. The mansion will act like you have exactly the right amount until the respective reward has been collected.
If you have enough shells, you can even get multiple rewards in a row without having to reload the room, the bar on the right will then just keep filling up after the previous reward has been collected. This should avoid player confusion, and make it not too annoying to get the final reward even if hidden seashells are set to vanilla.
Also, collecting the reward for 20 seashells no longer resets the seashell count.
All seeds besides seeds with the seashell hunt goal are affected by these changes.

I did not include any intentional changes in bomb trigger behavior. However, because the code checks the (modified) seashell count to determine the item (since it can now be different between 5 and 10 shells), and it does not have an item to give for other amounts, item duplication is prevented if the item is a seashell.