### PR TITLE
Fix d1 hard logic being applied to normal logic

### DIFF
--- a/logic/dungeon1.py
+++ b/logic/dungeon1.py
@@ -24,7 +24,7 @@ class Dungeon1:
         dungeon1_boss = Location(1).connect(dungeon1_miniboss, NIGHTMARE_KEY1)
         boss = Location(1).add(HeartContainer(0x106), Instrument(0x102)).connect(dungeon1_boss, r.boss_requirements[world_setup.boss_mapping[0]])
 
-        if options.logic not in ('normal', 'casual'):
+        if options.logic == 'hard' options.logic == 'glitched' or options.logic == 'hell':
             stalfos_keese_room.connect(entrance, r.attack_hookshot_powder) # stalfos jump away when you press a button.
             dungeon1_3_of_a_kind.connect(dungeon1_right_side, BOMB) # use timed bombs to match the 3 of a kinds
 

--- a/logic/dungeon1.py
+++ b/logic/dungeon1.py
@@ -24,7 +24,7 @@ class Dungeon1:
         dungeon1_boss = Location(1).connect(dungeon1_miniboss, NIGHTMARE_KEY1)
         boss = Location(1).add(HeartContainer(0x106), Instrument(0x102)).connect(dungeon1_boss, r.boss_requirements[world_setup.boss_mapping[0]])
 
-        if options.logic == 'hard' options.logic == 'glitched' or options.logic == 'hell':
+        if options.logic == 'hard' or options.logic == 'glitched' or options.logic == 'hell':
             stalfos_keese_room.connect(entrance, r.attack_hookshot_powder) # stalfos jump away when you press a button.
             dungeon1_3_of_a_kind.connect(dungeon1_right_side, BOMB) # use timed bombs to match the 3 of a kinds
 


### PR DESCRIPTION
the key for normal logic is an empty string '', while the hard logic checks for string 'normal'. Changed to fix it to the existing format of explicitly mentioning logic modes the logic should apply to