### PR TITLE
Fixed reading outdoors->outdoors when multiple doors on screen

### DIFF
--- a/patches/entrances.py
+++ b/patches/entrances.py
@@ -58,7 +58,10 @@ def readEntrances(rom):
         for other_key, other_info in ENTRANCE_INFO.items():
             if warp.room == other_info.target:
                 result[key] = f"{other_key}:inside"
-            if warp.room == other_info.room:
+            if (warp.room == other_info.room
+                and (other_info.x == None
+                     or (other_info.x == warp.target_x
+                         and other_info.y == warp.target_y))):
                 result[key] = other_key
 
         re = RoomEditor(rom, info.target)


### PR DESCRIPTION
Oops, the same fix from before also has to be applied here to catch outdoors->outdoors transitions.