### PR TITLE
Fix total check count

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -54,6 +54,7 @@ import patches.multiworld
 import patches.tradeSequence
 import patches.alttp
 import hints
+import locations.keyLocation
 
 
 # Function to generate a final rom, this patches the rom with all required patches
@@ -282,7 +283,7 @@ def generateRom(args, settings, seed, logic, *, rnd=None, multiworld=None):
         patches.enemies.randomizeEnemies(rom, seed)
 
     if not args.romdebugmode:
-        patches.core.addFrameCounter(rom, len(item_list))
+        patches.core.addFrameCounter(rom, len([spot for spot in item_list if type(spot) != locations.keyLocation.KeyLocation]))
 
     patches.core.warpHome(rom, settings.overworld == "dungeonchain" or settings.entranceshuffle in ("chaos", "insane", "madness"))  # Needs to be done after setting the start location.
     patches.titleScreen.setRomInfo(rom, binascii.hexlify(seed).decode("ascii").upper(), settings)


### PR DESCRIPTION
This makes it so KeyLocations aren't counted as checks for the total check count. KeyLocations aren't included in the counter for collected checks either, which means the total used to be higher than what was really obtainable (aside from doing things like resetting the game without saving to collect something multiple times).