### PR TITLE
Adjust armos maze traversal in normal logic to require an item to deal with armos

### DIFF
--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -301,11 +301,12 @@ class World:
         Location().add(HeartPiece(0x1E8)).connect(desert_cave, BOMB)  # above the quicksand cave
         Location().add(Seashell(0x0FF)).connect(desert, POWER_BRACELET) # bottom right corner of the map
 
-        armos_maze = Location().connect(animal_village, POWER_BRACELET)
+        armos_maze_entrance = Location().connect(animal_village, POWER_BRACELET)
+	armos_maze = Location().connect(armos_maze_entrance, OR(r.attack_hookshot, SHIELD))
         armos_temple = Location()
         Location().add(FaceKey()).connect(armos_temple, r.miniboss_requirements[world_setup.miniboss_mapping["armos_temple"]])
         if options.owlstatues == "both" or options.owlstatues == "overworld":
-            armos_maze.add(OwlStatue(0x08F))
+            armos_maze_entrance.add(OwlStatue(0x08F))
         self._addEntrance("armos_maze_cave", armos_maze, Location().add(Chest(0x2FC)), None)
         self._addEntrance("armos_temple", armos_maze, armos_temple, None)
 
@@ -488,7 +489,8 @@ class World:
             animal_village_bombcave_heartpiece.connect(animal_village_bombcave, r.boots_jump) # jump across horizontal 4 gap to heart piece
             animal_village_bombcave_heartpiece.connect(animal_village_bombcave, AND(BOMB, FEATHER, BOOMERANG))  # use jump + boomerang to grab the item from below the ledge
             desert_lanmola.connect(desert, BOMB) # use bombs to kill lanmola
-            
+
+            armos_maze.connect(armos_maze_entrance, None) # dodge the armos statues by activating them and running
             d6_connector_left.connect(d6_connector_right, AND(OR(FLIPPERS, PEGASUS_BOOTS), FEATHER))  # jump the gap in underground passage to d6 left side to skip hookshot
             obstacle_cave_exit.connect(obstacle_cave_inside, AND(FEATHER, r.hookshot_over_pit), one_way=True) # one way from right exit to middle, jump past the obstacle, and use hookshot to pull past the double obstacle
             if not options.rooster:

--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -306,8 +306,8 @@ class World:
         Location().add(FaceKey()).connect(armos_temple, r.miniboss_requirements[world_setup.miniboss_mapping["armos_temple"]])
         if options.owlstatues == "both" or options.owlstatues == "overworld":
             armos_maze.add(OwlStatue(0x08F))
-	outside_armos_cave = Location().connect(armos_maze, OR(r.attack_hookshot, SHIELD))
-	outside_armos_temple = Location().connect(armos_maze, OR(r.attack_hookshot, SHIELD))
+        outside_armos_cave = Location().connect(armos_maze, OR(r.attack_hookshot, SHIELD))
+        outside_armos_temple = Location().connect(armos_maze, OR(r.attack_hookshot, SHIELD))
         self._addEntrance("armos_maze_cave", outside_armos_cave, Location().add(Chest(0x2FC)), None)
         self._addEntrance("armos_temple", outside_armos_temple, armos_temple, None)
 

--- a/logic/overworld.py
+++ b/logic/overworld.py
@@ -301,14 +301,15 @@ class World:
         Location().add(HeartPiece(0x1E8)).connect(desert_cave, BOMB)  # above the quicksand cave
         Location().add(Seashell(0x0FF)).connect(desert, POWER_BRACELET) # bottom right corner of the map
 
-        armos_maze_entrance = Location().connect(animal_village, POWER_BRACELET)
-	armos_maze = Location().connect(armos_maze_entrance, OR(r.attack_hookshot, SHIELD))
+        armos_maze = Location().connect(animal_village, POWER_BRACELET)
         armos_temple = Location()
         Location().add(FaceKey()).connect(armos_temple, r.miniboss_requirements[world_setup.miniboss_mapping["armos_temple"]])
         if options.owlstatues == "both" or options.owlstatues == "overworld":
-            armos_maze_entrance.add(OwlStatue(0x08F))
-        self._addEntrance("armos_maze_cave", armos_maze, Location().add(Chest(0x2FC)), None)
-        self._addEntrance("armos_temple", armos_maze, armos_temple, None)
+            armos_maze.add(OwlStatue(0x08F))
+	outside_armos_cave = Location().connect(armos_maze, OR(r.attack_hookshot, SHIELD))
+	outside_armos_temple = Location().connect(armos_maze, OR(r.attack_hookshot, SHIELD))
+        self._addEntrance("armos_maze_cave", outside_armos_cave, Location().add(Chest(0x2FC)), None)
+        self._addEntrance("armos_temple", outside_armos_temple, armos_temple, None)
 
         armos_fairy_entrance = Location().connect(bay_water, FLIPPERS).connect(animal_village, POWER_BRACELET)
         self._addEntrance("armos_fairy", armos_fairy_entrance, None, BOMB)
@@ -490,7 +491,8 @@ class World:
             animal_village_bombcave_heartpiece.connect(animal_village_bombcave, AND(BOMB, FEATHER, BOOMERANG))  # use jump + boomerang to grab the item from below the ledge
             desert_lanmola.connect(desert, BOMB) # use bombs to kill lanmola
 
-            armos_maze.connect(armos_maze_entrance, None) # dodge the armos statues by activating them and running
+            armos_maze.connect(outside_armos_cave, None) # dodge the armos statues by activating them and running
+            armos_maze.connect(outside_armos_temple, None) # dodge the armos statues by activating them and running
             d6_connector_left.connect(d6_connector_right, AND(OR(FLIPPERS, PEGASUS_BOOTS), FEATHER))  # jump the gap in underground passage to d6 left side to skip hookshot
             obstacle_cave_exit.connect(obstacle_cave_inside, AND(FEATHER, r.hookshot_over_pit), one_way=True) # one way from right exit to middle, jump past the obstacle, and use hookshot to pull past the double obstacle
             if not options.rooster:


### PR DESCRIPTION
Adjust logic to move itemless armos maze to hard logic instead. Normal logic requires either:
-Bomb, Bow or Boomerang to kill the armos statues
-Sword or Shield to knock the armos away
-Hookshot to stun the armos and walk through

