### PR TITLE
Add pot throwing to hit the D3 switch to hard logic

### DIFF
--- a/logic/dungeon3.py
+++ b/logic/dungeon3.py
@@ -64,6 +64,8 @@ class Dungeon3:
             dungeon3_reverse_eye.connect(entrance, r.hookshot_over_pit) # hookshot the chest to get to the right side
             dungeon3_north_key_drop.connect(area_up, r.throw_pot) # use pots to kill the enemies
             dungeon3_south_key_drop.connect(area_down, r.throw_pot) # use pots to kill enemies
+            area_up.connect(dungeon3_raised_blocks_north, r.throw_pot, one_way=True) # use pots to hit the switch
+            area_up.connect(dungeon3_raised_blocks_east, AND(r.throw_pot, r.attack_hookshot_powder), one_way=True) # use pots to hit the switch
 
         if options.logic == 'glitched' or options.logic == 'hell':
             area2.connect(dungeon3_raised_blocks_east, AND(r.attack_hookshot_powder, r.super_jump_feather), one_way=True) # use superjump to get over the bottom left block


### PR DESCRIPTION
Using pots to kill enemies gets you into D3's switch room in hard logic. This lets you use a pot to hit the switch itself to access the two switch locked chests.