### PR TITLE
Add a script to launch the LADXR web UI locally (issue #56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,14 @@ Basic usage:
 
 The script will generate a new rom with item locations shuffled. There are many options, see `-h` on the script for details.
 
+There's also a little helper that launches the web UI locally:
+
+`python3 launch_web_ui.py`
+
 ## Development
 
 This is still in the early stage of development. Important bits are:
 * `randomizer.py`: Contains the actual logic to randomize the rom, and checks to make sure it can be solved.
 * `logic/*.py`: Contains the logic definitions of what connects to what in the world and what it requires to access that part.
 * `locations/*.py`: Contains definitions of location types, and what items can be there. As well as the code on how to place an item there. For example the Chest class has a list of all items that can be in a chest. And the needed rom patch to put that an item in a specific chest.
-* `patches/*.py`: Various patches on the code that are not directly related to a specific location. But more general fixes 
+* `patches/*.py`: Various patches on the code that are not directly related to a specific location. But more general fixes

--- a/launch_web_ui.py
+++ b/launch_web_ui.py
@@ -1,0 +1,106 @@
+"""Sets up a small web server that hosts the LADXR web UI, and opens
+the main page a browser.
+"""
+
+import argparse
+import webbrowser
+import http.server
+import mimetypes
+import os
+import socketserver
+import tarfile
+import tempfile
+import threading
+import time
+
+
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+SERVE_DIR = os.path.join(BASE_DIR, 'www')
+
+
+parser = argparse.ArgumentParser(
+    prog='LADXR Web Launcher',
+    description='Launches the LADXR web UI locally and opens a browser')
+parser.add_argument(
+    '-p', '--port',
+    default=8000,
+    required=False,
+    type=int,
+    help='Port on which the web server will listen')
+args = parser.parse_args()
+
+
+class LADXRHandler(http.server.SimpleHTTPRequestHandler):
+    """The request handler for the TCPServer.
+
+    Everything in the directory www will be automatically served at
+    the root url / (so www/index.html will be served as /index.html
+    etc.)
+
+    However, we need to set up a couple of custom routes:
+
+    * All links going to /LADXR/gfx/ are outside the serving directory,
+      so we need to serve them manally
+    * /js/ladxr.tar.gz will be created on the fly and served
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs['directory'] = SERVE_DIR
+        super().__init__(*args, **kwargs)
+
+    def send_file_response(self, filename):
+        self.send_response(200)
+        self.send_header('Content-type', mimetypes.guess_type(filename))
+        self.end_headers()
+        with open(filename, 'rb') as f:
+            self.wfile.write(f.read())
+
+    def do_GET(self):
+        if self.path == '/js/ladxr.tar.gz':
+            # Create the tgz file in a temporary directory and serve it
+            with tempfile.TemporaryDirectory() as dirname:
+                src = BASE_DIR
+                dest = os.path.join(dirname, 'ladxr.targ.gz')
+                with tarfile.open(dest, 'w:gz') as tar:
+                    tar.add(src, arcname='')
+
+                self.send_file_response(dest)
+                return
+        if self.path.startswith('/LADXR/gfx/'):
+            # We are serving from LADXR/www/, but graphics are outside
+            # our scope at LADXR/gfx/, so serve graphics manually:
+            filename = os.path.join(
+                BASE_DIR, self.path.removeprefix('/LADXR/'))
+            self.send_file_response(filename)
+            return
+        else:
+            # Serve directly from LADXR/www/
+            return super().do_GET()
+
+
+class ServerThread(threading.Thread):
+    """Run TCP serven in a background thread so that we can launch a web
+    browser in the main thread.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.daemon = True
+
+    def run(self):
+        with socketserver.TCPServer(('', args.port), LADXRHandler) as httpd:
+            httpd.serve_forever()
+
+
+if __name__ == '__main__':
+    try:
+        thread = ServerThread()
+        thread.start()
+        url = f'http://localhost:{args.port}'
+        print('If your browser doesn\'t open automatically, visit:')
+        print(url)
+        webbrowser.open(url)
+        while True:
+            time.sleep(100)
+    except (KeyboardInterrupt, SystemExit):
+        print('Received keyboard interrupt, quitting threads.')

--- a/launch_web_ui.py
+++ b/launch_web_ui.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """Sets up a small web server that hosts the LADXR web UI, and opens
 the main page a browser.
 """
@@ -60,7 +62,7 @@ class LADXRHandler(http.server.SimpleHTTPRequestHandler):
             # Create the tgz file in a temporary directory and serve it
             with tempfile.TemporaryDirectory() as dirname:
                 src = BASE_DIR
-                dest = os.path.join(dirname, 'ladxr.targ.gz')
+                dest = os.path.join(dirname, 'ladxr.tar.gz')
                 with tarfile.open(dest, 'w:gz') as tar:
                     tar.add(src, arcname='')
 


### PR DESCRIPTION
The script sets up a simple local server with standard Python tools and serves the web UI. It then launches a browser window with the main page.

Note that this relies on the basic directory structure of the served files, and the URLS under which they are requested, to remain the same:

* The contents of the www folder being served at top level
* The contents of the gfx folder being served at LADXR/gfx/
* The tgz file being served at /js/ladxr.tar.gz

So any restructuring will require adjustments in the launcher script. Changes soley within the www and gfx folders are no problem.