### PR TITLE
patch the color book shadow

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -53,6 +53,7 @@ import patches.maze
 import patches.multiworld
 import patches.tradeSequence
 import patches.alttp
+import patches.colorBook
 import hints
 import locations.keyLocation
 
@@ -185,6 +186,7 @@ def generateRom(args, settings, seed, logic, *, rnd=None, multiworld=None):
     # patches.reduceRNG.slowdownThreeOfAKind(rom)
     patches.reduceRNG.fixHorseHeads(rom)
     patches.bomb.onlyDropBombsWhenHaveBombs(rom)
+    patches.colorBook.fixColorBook(rom)
     patches.aesthetics.noSwordMusic(rom)
     patches.aesthetics.reduceMessageLengths(rom, rnd)
     patches.aesthetics.allowColorDungeonSpritesEverywhere(rom)

--- a/patches/colorBook.py
+++ b/patches/colorBook.py
@@ -1,0 +1,7 @@
+from assembler import ASM
+
+def fixColorBook(rom):
+    # patch to repair the color book shadow/flags. Can still fire projectiles over the book.
+    rom.patch(0x03, 0x004A, "F2", "A2")
+    # patch hitbox flags to match 1.2
+    rom.patch(0x03, 0x0145, "80", "98")

--- a/patches/marin.txt
+++ b/patches/marin.txt
@@ -224,7 +224,7 @@ Thank you Link, but our Instruments are in another Dungeon.
 Are you sure you loaded the right seed?
 Is this even randomized?
 This seed brought to you by... Corners!
-To this day I still don't know if we inconvienced the Mad Batter or not.
+To this day I still don't know if we inconvenienced the Mad Batter or not.
 Oh, hi #####
 People forgot I was playable in Hyrule Warriors
 Join our Discord.  Or else.


### PR DESCRIPTION
also fix a typo in marin splash. the book no longer has the ENTITY_PHYSICS_GRABBABLE and ENTITY_PHYSICS_SHADOW flags set.