### PR TITLE
de-deprecate github workflow

### DIFF
--- a/.github/workflows/multiworld_build.yml
+++ b/.github/workflows/multiworld_build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -30,7 +30,7 @@ jobs:
         cd multiworld
         pyinstaller --clean -y client.py -n multiworldclient
     - name: Upload windows dist build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: multiworld-client-windows
         path: multiworld/dist/multiworldclient

--- a/.github/workflows/python-parse-test.yml
+++ b/.github/workflows/python-parse-test.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - run: python3 main.py -h


### PR DESCRIPTION
updates the workflow dependencies from node.js 16 to 20 (this removes the nagging about node.js in github actions)