### PR TITLE
dungeon dive itempool adjustment

### DIFF
--- a/itempool.py
+++ b/itempool.py
@@ -175,6 +175,8 @@ class ItemPool:
 
         if settings.overworld == "dungeondive":
             self.remove(SWORD)
+            self.remove(SHOVEL)
+            self.remove(TOADSTOOL)
             self.remove(MAX_ARROWS_UPGRADE)
             self.remove(MAX_BOMBS_UPGRADE)
             self.remove(MAX_POWDER_UPGRADE)
@@ -188,6 +190,7 @@ class ItemPool:
             self.remove(SONG2)
             self.remove(SONG3)
             self.remove(HEART_PIECE, 8)
+            self.add(HEART_CONTAINER, 2)
             self.remove(RUPEES_50, 9)
             self.removeRupees(5-self.get(MEDICINE))
             self.remove(MEDICINE, self.get(MEDICINE))


### PR DESCRIPTION
swap the useless shovel/shroom with two hearts. the shovel does admittedly allow for rupee and heart farming in the safe areas, but so does cutting grass.
this would make a full heartbar on otherwise normal settings.

personally i would like one of the twenty rupee chests to be swapped out with a medicine, but that's just my opinion, and not having medicine makes for an interesting challenge. having one (1) medicine available would be neat though