### PR TITLE
The owlstatues default is '', not 'none'

### DIFF
--- a/itempool.py
+++ b/itempool.py
@@ -159,7 +159,7 @@ class ItemPool:
                 self.remove(f"COMPASS{n}")
                 self.add(f"KEY{n}")
                 self.add(f"NIGHTMARE_KEY{n}")
-            if settings.owlstatues in ("none", "overworld"):
+            if settings.owlstatues in ("", "overworld"):
                 for n in range(9):
                     self.remove(f"STONE_BEAK{n}")
                     self.add(f"KEY{n}")


### PR DESCRIPTION
Pretty much just the title - I happened to notice this while working on Magpie. I didn't find the same issue anywhere else.