### PR TITLE
Format text with diacritics + a new Marin sentence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ dmypy.json
 cython_debug/
 
 *.gbc
+*.sav
 .vscode
 LADXR_*.txt
 LADXR_*.json

--- a/patches/marin.txt
+++ b/patches/marin.txt
@@ -246,6 +246,7 @@ So the bear is just calling the walrus fat beecause he's projecting, right?
 Please help, #####!  The Nightmare has shuffled all the items around!
 One does not simply Wake the Wind Fish.
 Nothing unusual here, just a completely normal LADX game, Mister Nintendo.
+Ah! Enfin...\n J'ai cru que tu n'allais jamais te r<eacute>veiller.\nTu devais cauchemarder.\nQuoi? Zelda??\nTu dois <ecirc>tre encore patraque! Je suis Marine! Tu es sur l'<icirc>le Cocolint!
 
 
 

--- a/patches/marin.txt
+++ b/patches/marin.txt
@@ -1,6 +1,6 @@
 Let's a go!
-Remember, sword goes on A!
-Remember, sword goes on B!
+Remember, sword goes on <bigA>!
+Remember, sword goes on <bigB>!
 It's pronounced Hydrocity Zone.
 Avoid the heart piece of shame!
 Marin? No, this is Zelda. Welcome to Hyrule
@@ -30,7 +30,7 @@ Go try Archipelago!
 Go try touching grass!
 Please leave my house.
 Trust me, this will be a 2 hour seed, max.
-This is still better than doing Dampe dungeons.
+This is still better than doing Damp<eacute> dungeons.
 They say that Marin can be found here.
 Stalfos are such boneheads.
 90 percent bug-free!
@@ -76,7 +76,7 @@ Try this rando at ladxr.daid.eu!
 He turned himself into a carpet whale!
 Which came first, the whale or the egg?
 Glan - Known Death and Taxes appreciator.
-Pokemon number 591.
+Pok<eacute>mon number 591.
 Would you?
 Sprinkle the desert skulls.
 Please don't curse in my Christian LADXR seed.

--- a/utils.py
+++ b/utils.py
@@ -146,6 +146,57 @@ _NAMES = {
 }
 
 
+_CHARACTERS = {
+    b"'":  b"^",
+    b'<agrave>': b'\x80',
+    b'<acirc>' : b'\x81',
+    b'<auml>'  : b'\x82',
+    b'<egrave>': b'\x83',
+    b'<eacute>': b'\x84',
+    b'<ecirc>' : b'\x85',
+    b'<ugrave>': b'\x86',
+    b'<ucirc>' : b'\x87',
+    b'<uuml>'  : b'\x88',
+    b'<ocirc>' : b'\x89',
+    b'<ouml>'  : b'\x8A',
+    b'<ccedil>': b'\x8B',
+    b'<icirc>' : b'\x8C',
+    # b'<szlig>' : b'\x8D',
+    # b'<Auml>'  : b'\x8E',
+    # b'<Ouml>'  : b'\x8F',
+    # b'<Uuml>'  : b'\x90',
+    b'<bigA>'  : b'\xD0',
+    b'<bigB>'  : b'\xD1',
+    b'<bigC>'  : b'\xD2',
+    b'<bigD>'  : b'\xD3',
+    b'<bigE>'  : b'\xD4',
+    b'<bigF>'  : b'\xD5',
+    b'<foot>'  : b'\xDA',
+    b'<master>': b'\xDC',
+    b'<link>'  : b'\xDD',
+    b'<marin>' : b'\xDE',
+    b'<tarkin>': b'\xDF',
+    b'<yoshi>' : b'\xE0',
+    b'<ribbon>': b'\xE1',
+    b'<dogfood>':b'\xE2',
+    b'<bananas>': b'\xE3',
+    b'<stick>' : b'\xE4',
+    b'<honeycomb>': b'\xE5',
+    b'<pineapple>': b'\xE6',
+    b'<hibiscus>': b'\xE7',
+    b'<broom>' : b'\xE8',
+    b'<hook>'  : b'\xE9',
+    b'<necklace>':b'\xEA',
+    b'<scale>' : b'\xEB',
+    b'<glass>' : b'\xEC',
+    b'<letter>': b'\xED',
+    b'<dpad>'  : b'\xEE',
+    b'<arrowU>': b'\xF0',
+    b'<arrowD>': b'\xF1',
+    b'<arrowL>': b'\xF2',
+    b'<arrowR>': b'\xF3',
+}
+
 def setReplacementName(key: str, value: str) -> None:
     _NAMES[key] = value
 
@@ -153,7 +204,8 @@ def setReplacementName(key: str, value: str) -> None:
 def formatText(instr: str, *, center: bool = False, ask: Optional[str] = None) -> bytes:
     instr = instr.format(**_NAMES)
     s = instr.encode("ascii")
-    s = s.replace(b"'", b"^").replace(b'<honeycomb>', b'\xE5')
+    for character, encodedCharacter in _CHARACTERS.items():
+        s = s.replace(character, encodedCharacter)
 
     def padLine(line: bytes) -> bytes:
         return line + b' ' * (16 - len(line))


### PR DESCRIPTION
This PR add support for more special characters with some Marin text update, and a new one based on the French translation. [(a LADX French playthrough showing the text)](https://youtu.be/LjA-Jv3hreI?si=Oedbx-qGwlmxuK4H&t=22)

I saw `ß`, `Ä`, `Ö` and `Ü` characters are in the ROM graphics but does not seem to be mapped in the US version.

Unrelated to special characters, I saw that .gitignore has .gbc files in it, but not .sav files so I added them too.